### PR TITLE
Folder-tree knowledge source (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,33 @@ The tuple maps to a `TraversalStrategy` (edge filters, depth, weight floor, budg
 
 SQLite + `sqlite-vec` for vector similarity on seed selection. Property graph emulated via two tables. One file, no ops.
 
+## Authoring
+
+Knowledge is authored as a **folder tree** — one folder per node, a `readme.md` with YAML frontmatter for content and metadata, and an optional `edges.yaml` for outgoing typed edges. The tree is the source of truth; SQLite is a rebuildable index. Everything is git-diffable.
+
+```
+knowledge/
+├── exercises/
+│   ├── bench-press/
+│   │   ├── readme.md       ← frontmatter + body
+│   │   └── edges.yaml      ← outgoing edges with type, weight, content
+│   └── squat/
+│       ├── readme.md
+│       └── edges.yaml
+└── rules/
+    └── progression/
+        ├── readme.md       ← JSON rule body
+        └── edges.yaml      ← falls_back_to: deload
+```
+
+See [`docs/adr/0001-knowledge-source.md`](docs/adr/0001-knowledge-source.md) for the full rationale (why not Obsidian).
+
+```bash
+ctx --db graph.db import fixtures/tree       # build
+ctx --db graph.db query "Why do I avoid squats?" --seed exercises/squat
+ctx --db graph.db export fixtures/tree       # write back (feedback loop uses this)
+```
+
 ## Status
 
 Phase 0 — scaffolding. Design stable, implementation in progress.

--- a/docs/adr/0001-knowledge-source.md
+++ b/docs/adr/0001-knowledge-source.md
@@ -1,0 +1,131 @@
+# ADR 0001 — Knowledge source format
+
+**Status**: accepted
+**Date**: 2026-04-07
+
+## Context
+
+The engine needs an authoritative source of truth for nodes and edges that
+humans can author, review, and version. The design doc listed Obsidian as a
+candidate but left the decision open. Three options were considered:
+
+1. Obsidian vault (markdown + wikilinks + YAML frontmatter)
+2. Hierarchical folder tree (one folder per node, `readme.md` for content,
+   `edges.yaml` for outgoing edges)
+3. SQLite as source of truth, CLI / web UI for editing
+
+## Decision
+
+Adopt **option 2: hierarchical folder tree**. SQLite remains the query-time
+index, rebuilt from the tree. The tree is the source of truth.
+
+## Rationale
+
+**Identity is path-based but git-mediated.** Node ids are relative paths
+(`exercises/bench-press`). Renames are `git mv` plus reference updates — a
+reviewable commit, not a silent file-watcher event.
+
+**Edges are explicit and rich.** `edges.yaml` holds the `type`, `weight`, and
+`content` each `Edge` requires. Obsidian's `[[wikilink]]` cannot express
+weighted, typed, annotated edges without fighting the tool.
+
+**Git is the versioning story.** History, blame, branches, PR review, rollback
+— all free. The feedback loop writes weight updates back into `edges.yaml`
+so every tuning step is a reviewable commit.
+
+**No GUI dependency.** Any text editor works. CI can import, mutate, export,
+and diff the tree. Obsidian may still sit on top as a read-only vault but
+does not own the data.
+
+**Filesystem as implicit structure.** Parent folders become implicit
+`part_of` edges derived at import time; named hierarchies become
+`instance_of`. The `edges.yaml` file contains only semantic edges, keeping
+it small and human-scannable.
+
+## Consequences
+
+- A folder tree ↔ SQLite importer becomes part of the core library.
+- The feedback loop gains a second writer target (`edges.yaml`) in addition
+  to SQLite. The tree is canonical; SQLite is rebuildable.
+- Authoring tooling is BYO — a future VS Code extension or schema-aware
+  editor is a nice-to-have, not a blocker.
+- Round-trip tests verify that `import(export(tree)) == tree` modulo
+  derived structural edges.
+
+## Format
+
+Directory layout::
+
+    knowledge/
+      <domain>/
+        <node-slug>/
+          readme.md          # content + YAML frontmatter metadata
+          edges.yaml         # optional — outgoing edges
+
+### `readme.md`
+
+```markdown
+---
+type: exercise
+status: avoided
+domain: fitness
+tags: [legs, compound]
+---
+
+The squat is a compound lower-body lift performed with a loaded barbell
+on the upper back.
+```
+
+Frontmatter becomes `Node.metadata`. Body becomes `Node.content`.
+
+### `edges.yaml`
+
+```yaml
+edges:
+  - target: conditions/knee-pain
+    type: because_of
+    weight: 0.9
+    content: Squats aggravate a chronic meniscus issue.
+  - target: rules/progression
+    type: if_then
+    weight: 0.6
+```
+
+`target` is a path relative to `knowledge/`. `type` and `weight` are required.
+`content` is optional — the "why" of the relationship.
+
+### Rule nodes
+
+A node with `type: rule` in its frontmatter has its body treated as the rule
+definition. For the Python logic engine, the body is a fenced JSON block. A
+later Prolog bridge will accept Prolog clauses.
+
+```markdown
+---
+type: rule
+name: progression
+---
+
+```json
+{
+  "predicate": "threshold",
+  "args": {"metric": "bench_weight", "op": ">", "value": 65},
+  "on_pass": "increase weight by 2.5kg",
+  "on_fail": "maintain current weight"
+}
+```
+```
+
+### Derived structural edges
+
+Import walks parent folders and synthesises a `part_of` edge from each node
+to its parent folder node (if the parent also has a `readme.md`). These
+edges are never written back to `edges.yaml`.
+
+## Alternatives rejected
+
+**Obsidian** — path-based identity plus silent renames plus weak edge typing
+make it unsuitable as a source of truth. Can still read the tree as a vault.
+
+**SQLite canonical** — no diffable history, no PR review, no rollback. Fine
+for ephemeral state but wrong for knowledge that humans author and curate.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -79,6 +79,14 @@ Phased, each phase produces a runnable system that passes its own tests.
 - Source reliability scaling: user > logic_engine > llm
 - Tests: helpful edges strengthen, learned edges get created
 
+## Phase 9 — folder-tree knowledge source ✅
+
+- ADR 0001 decides on the folder-tree format over Obsidian
+- `FolderTreeSource` imports/exports the SQLite store
+- Derived `part_of` edges synthesised from parent folders; never written back
+- Fixture tree in `fixtures/tree/` used for round-trip tests
+- `ctx import` / `ctx export` CLI commands
+
 ## Next (beyond v0.1)
 
 1. **LLM classifier** — drop-in replacement for `KeywordClassifier`, uses

--- a/fixtures/tree/conditions/knee-pain/readme.md
+++ b/fixtures/tree/conditions/knee-pain/readme.md
@@ -1,0 +1,6 @@
+---
+type: condition
+domain: fitness
+status: active
+---
+Chronic medial meniscus irritation. Triggered by deep knee flexion under load.

--- a/fixtures/tree/conditions/readme.md
+++ b/fixtures/tree/conditions/readme.md
@@ -1,0 +1,4 @@
+---
+type: category
+---
+Physical conditions that affect exercise selection.

--- a/fixtures/tree/exercises/bench-press/edges.yaml
+++ b/fixtures/tree/exercises/bench-press/edges.yaml
@@ -1,0 +1,5 @@
+edges:
+  - target: rules/progression
+    type: if_then
+    weight: 0.6
+    content: Apply the progression rule to this exercise.

--- a/fixtures/tree/exercises/bench-press/readme.md
+++ b/fixtures/tree/exercises/bench-press/readme.md
@@ -1,0 +1,8 @@
+---
+type: exercise
+domain: fitness
+tags:
+  - push
+  - compound
+---
+Barbell bench press. Primary horizontal push, flat back arch, bar to mid-chest.

--- a/fixtures/tree/exercises/readme.md
+++ b/fixtures/tree/exercises/readme.md
@@ -1,0 +1,5 @@
+---
+type: category
+domain: fitness
+---
+Exercises in the current training programme.

--- a/fixtures/tree/exercises/squat/edges.yaml
+++ b/fixtures/tree/exercises/squat/edges.yaml
@@ -1,0 +1,5 @@
+edges:
+  - target: conditions/knee-pain
+    type: because_of
+    weight: 0.9
+    content: Squats aggravate a chronic meniscus issue.

--- a/fixtures/tree/exercises/squat/readme.md
+++ b/fixtures/tree/exercises/squat/readme.md
@@ -1,0 +1,9 @@
+---
+type: exercise
+domain: fitness
+status: avoided
+tags:
+  - legs
+  - compound
+---
+Back squat. Currently avoided pending knee rehab.

--- a/fixtures/tree/rules/deload/readme.md
+++ b/fixtures/tree/rules/deload/readme.md
@@ -1,0 +1,5 @@
+---
+type: rule
+name: deload
+---
+{"predicate": "threshold", "args": {"metric": "ohp_weight", "op": "<", "value": 40}, "on_pass": "deload to 80% for one session", "on_fail": "continue"}

--- a/fixtures/tree/rules/progression/edges.yaml
+++ b/fixtures/tree/rules/progression/edges.yaml
@@ -1,0 +1,5 @@
+edges:
+  - target: rules/deload
+    type: falls_back_to
+    weight: 0.5
+    content: When progression fails, deload.

--- a/fixtures/tree/rules/progression/readme.md
+++ b/fixtures/tree/rules/progression/readme.md
@@ -1,0 +1,5 @@
+---
+type: rule
+name: progression
+---
+{"predicate": "threshold", "args": {"metric": "bench_weight", "op": ">", "value": 65}, "on_pass": "increase weight by 2.5kg", "on_fail": "maintain current weight"}

--- a/fixtures/tree/rules/readme.md
+++ b/fixtures/tree/rules/readme.md
@@ -1,0 +1,4 @@
+---
+type: category
+---
+Deterministic rules evaluated by the logic engine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "sqlite-vec>=0.1.6",
     "anthropic>=0.40.0",
     "numpy>=1.26",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -19,6 +20,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.5",
     "mypy>=1.10",
+    "types-pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -16,6 +16,7 @@ import sys
 from pathlib import Path
 
 from context_engine.engine import ContextEngine
+from context_engine.source import FolderTreeSource
 from context_engine.store import GraphStore
 from context_engine.types import Query
 
@@ -47,6 +48,12 @@ def main(argv: list[str] | None = None) -> int:
     p_query.add_argument("--filter", help="metadata filter as JSON")
 
     sub.add_parser("dump")
+
+    p_import = sub.add_parser("import", help="build the graph from a folder tree")
+    p_import.add_argument("tree", help="path to the knowledge/ root")
+
+    p_export = sub.add_parser("export", help="write the graph back to a folder tree")
+    p_export.add_argument("tree", help="path to the knowledge/ root")
 
     args = parser.parse_args(argv)
     store = GraphStore(Path(args.db))
@@ -86,6 +93,22 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "dump":
         print(f"nodes: {store.node_count()}  edges: {store.edge_count()}")
+        return 0
+
+    if args.cmd == "import":
+        source = FolderTreeSource(args.tree)
+        report = source.import_into(store)
+        print(
+            f"imported {report.nodes} nodes, "
+            f"{report.explicit_edges} explicit edges, "
+            f"{report.derived_edges} derived edges"
+        )
+        return 0
+
+    if args.cmd == "export":
+        source = FolderTreeSource(args.tree)
+        source.export_from(store)
+        print(f"exported {store.node_count()} nodes to {args.tree}")
         return 0
 
     parser.print_help()

--- a/src/context_engine/source.py
+++ b/src/context_engine/source.py
@@ -1,0 +1,262 @@
+"""Folder-tree knowledge source.
+
+Source of truth is a directory tree under ``knowledge/``. Each node is a
+folder containing:
+
+  - ``readme.md``   — YAML frontmatter (metadata) + body (content)
+  - ``edges.yaml``  — optional outgoing edges
+
+Node id is the path relative to the tree root, POSIX-normalised
+(``exercises/bench-press``). The importer rebuilds the SQLite store from the
+tree. The exporter writes the current store state back to the tree — used
+by the feedback loop so weight updates are reviewable in git.
+
+Structural edges derived from parent folders (``part_of``) are never written
+back to ``edges.yaml``.
+
+See ``docs/adr/0001-knowledge-source.md`` for the full rationale.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from context_engine.store import GraphStore
+
+README = "readme.md"
+EDGES_FILE = "edges.yaml"
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+# ── parse / serialise single node ──────────────────────────────────────────
+
+
+@dataclass
+class ParsedNode:
+    node_id: str
+    content: str
+    metadata: dict[str, Any]
+
+
+@dataclass
+class ParsedEdge:
+    source: str
+    target: str
+    edge_type: str
+    weight: float
+    content: str | None
+
+
+def parse_readme(path: Path, node_id: str) -> ParsedNode:
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if match:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+        body = match.group(2).strip()
+    else:
+        frontmatter = {}
+        body = text.strip()
+    if not isinstance(frontmatter, dict):
+        raise SourceError(f"{path}: frontmatter must be a mapping")
+    return ParsedNode(
+        node_id=node_id,
+        content=body,
+        metadata=frontmatter,
+    )
+
+
+def parse_edges(path: Path, source_id: str) -> list[ParsedEdge]:
+    if not path.exists():
+        return []
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise SourceError(f"{path}: top level must be a mapping")
+    items = raw.get("edges", [])
+    if not isinstance(items, list):
+        raise SourceError(f"{path}: 'edges' must be a list")
+
+    out: list[ParsedEdge] = []
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise SourceError(f"{path}: edge[{i}] must be a mapping")
+        try:
+            out.append(
+                ParsedEdge(
+                    source=source_id,
+                    target=str(item["target"]),
+                    edge_type=str(item["type"]),
+                    weight=float(item.get("weight", 0.5)),
+                    content=item.get("content"),
+                )
+            )
+        except KeyError as exc:
+            raise SourceError(f"{path}: edge[{i}] missing {exc}") from exc
+    return out
+
+
+def serialise_readme(node: ParsedNode) -> str:
+    frontmatter = yaml.safe_dump(node.metadata, sort_keys=True).strip()
+    return f"---\n{frontmatter}\n---\n{node.content.rstrip()}\n"
+
+
+def serialise_edges(edges: list[ParsedEdge]) -> str:
+    payload = {
+        "edges": [
+            {
+                k: v
+                for k, v in {
+                    "target": e.target,
+                    "type": e.edge_type,
+                    "weight": round(e.weight, 4),
+                    "content": e.content,
+                }.items()
+                if v is not None
+            }
+            for e in edges
+        ]
+    }
+    return yaml.safe_dump(payload, sort_keys=False)
+
+
+# ── importer ───────────────────────────────────────────────────────────────
+
+
+class SourceError(Exception):
+    pass
+
+
+class FolderTreeSource:
+    """Round-trip a folder tree with a ``GraphStore``."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root).resolve()
+
+    # ── import ─────────────────────────────────────────────────────────────
+
+    def walk_nodes(self) -> Iterable[ParsedNode]:
+        """Yield every node in the tree."""
+        if not self.root.exists():
+            raise SourceError(f"source root does not exist: {self.root}")
+        for readme in sorted(self.root.rglob(README)):
+            node_id = self._id_for(readme.parent)
+            yield parse_readme(readme, node_id)
+
+    def walk_edges(self) -> Iterable[ParsedEdge]:
+        """Yield every explicit edge declared under the tree."""
+        for edges_file in sorted(self.root.rglob(EDGES_FILE)):
+            source_id = self._id_for(edges_file.parent)
+            yield from parse_edges(edges_file, source_id)
+
+    def derive_structural_edges(
+        self, node_ids: set[str]
+    ) -> Iterable[ParsedEdge]:
+        """Synthesise ``part_of`` edges from child to parent folder nodes."""
+        for nid in node_ids:
+            parent = str(Path(nid).parent).replace("\\", "/")
+            if parent in (".", "/"):
+                continue
+            if parent in node_ids:
+                yield ParsedEdge(
+                    source=nid,
+                    target=parent,
+                    edge_type="part_of",
+                    weight=0.5,
+                    content=None,
+                )
+
+    def import_into(self, store: GraphStore) -> ImportReport:
+        """Rebuild the graph store from the tree."""
+        nodes = list(self.walk_nodes())
+        node_ids = {n.node_id for n in nodes}
+
+        for node in nodes:
+            store.upsert_node(
+                content=node.content,
+                metadata=node.metadata,
+                node_id=node.node_id,
+            )
+
+        edges = list(self.walk_edges())
+        for edge in edges:
+            if edge.target not in node_ids:
+                raise SourceError(
+                    f"edge {edge.source} → {edge.target}: target does not exist"
+                )
+            self._upsert_edge(store, edge, derived=False)
+
+        derived_count = 0
+        for edge in self.derive_structural_edges(node_ids):
+            self._upsert_edge(store, edge, derived=True)
+            derived_count += 1
+
+        return ImportReport(
+            nodes=len(nodes),
+            explicit_edges=len(edges),
+            derived_edges=derived_count,
+        )
+
+    @staticmethod
+    def _upsert_edge(
+        store: GraphStore, edge: ParsedEdge, derived: bool
+    ) -> None:
+        edge_id = f"{edge.source}::{edge.edge_type}::{edge.target}"
+        store.upsert_edge(
+            source=edge.source,
+            target=edge.target,
+            edge_type=edge.edge_type,
+            weight=edge.weight,
+            content=edge.content,
+            metadata={"derived": derived},
+            edge_id=edge_id,
+        )
+
+    # ── export ─────────────────────────────────────────────────────────────
+
+    def export_from(self, store: GraphStore) -> None:
+        """Write every node and non-derived edge from the store back to disk."""
+        for nid in store.all_node_ids():
+            node = store.get_node(nid)
+            if node is None:
+                continue
+            folder = self.root / nid
+            folder.mkdir(parents=True, exist_ok=True)
+            parsed = ParsedNode(
+                node_id=nid, content=node.content, metadata=node.metadata
+            )
+            (folder / README).write_text(serialise_readme(parsed), encoding="utf-8")
+
+            explicit = [
+                ParsedEdge(
+                    source=e.source,
+                    target=e.target,
+                    edge_type=e.type,
+                    weight=e.weight,
+                    content=e.content,
+                )
+                for e in store.out_edges(nid)
+                if not e.metadata.get("derived", False)
+            ]
+            edges_path = folder / EDGES_FILE
+            if explicit:
+                edges_path.write_text(serialise_edges(explicit), encoding="utf-8")
+            elif edges_path.exists():
+                edges_path.unlink()
+
+    # ── helpers ────────────────────────────────────────────────────────────
+
+    def _id_for(self, folder: Path) -> str:
+        rel = folder.resolve().relative_to(self.root)
+        return rel.as_posix()
+
+
+@dataclass
+class ImportReport:
+    nodes: int
+    explicit_edges: int
+    derived_edges: int

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from context_engine.source import (
+    FolderTreeSource,
+    ParsedEdge,
+    ParsedNode,
+    SourceError,
+    parse_edges,
+    parse_readme,
+    serialise_edges,
+    serialise_readme,
+)
+from context_engine.store import GraphStore
+
+FIXTURE_TREE = Path(__file__).resolve().parents[1] / "fixtures" / "tree"
+
+
+# ── parse / serialise round-trip ───────────────────────────────────────────
+
+
+def test_parse_readme_extracts_frontmatter_and_body(tmp_path: Path) -> None:
+    path = tmp_path / "readme.md"
+    path.write_text(
+        "---\n"
+        "type: exercise\n"
+        "status: avoided\n"
+        "---\n"
+        "Body text here.\n",
+        encoding="utf-8",
+    )
+    node = parse_readme(path, "exercises/squat")
+    assert node.node_id == "exercises/squat"
+    assert node.metadata == {"type": "exercise", "status": "avoided"}
+    assert node.content == "Body text here."
+
+
+def test_parse_readme_without_frontmatter(tmp_path: Path) -> None:
+    path = tmp_path / "readme.md"
+    path.write_text("Just a body.\n", encoding="utf-8")
+    node = parse_readme(path, "x")
+    assert node.metadata == {}
+    assert node.content == "Just a body."
+
+
+def test_parse_edges(tmp_path: Path) -> None:
+    path = tmp_path / "edges.yaml"
+    path.write_text(
+        "edges:\n"
+        "  - target: rules/progression\n"
+        "    type: if_then\n"
+        "    weight: 0.6\n"
+        "  - target: conditions/knee\n"
+        "    type: because_of\n"
+        "    weight: 0.9\n"
+        "    content: aggravates meniscus\n",
+        encoding="utf-8",
+    )
+    edges = parse_edges(path, "exercises/squat")
+    assert len(edges) == 2
+    assert edges[0].target == "rules/progression"
+    assert edges[0].weight == 0.6
+    assert edges[1].content == "aggravates meniscus"
+
+
+def test_parse_edges_missing_target(tmp_path: Path) -> None:
+    path = tmp_path / "edges.yaml"
+    path.write_text("edges:\n  - type: if_then\n", encoding="utf-8")
+    with pytest.raises(SourceError):
+        parse_edges(path, "x")
+
+
+def test_serialise_round_trip(tmp_path: Path) -> None:
+    node = ParsedNode(
+        node_id="exercises/bench",
+        content="Body paragraph.",
+        metadata={"type": "exercise", "tags": ["push", "compound"]},
+    )
+    text = serialise_readme(node)
+    (tmp_path / "readme.md").write_text(text, encoding="utf-8")
+    parsed = parse_readme(tmp_path / "readme.md", "exercises/bench")
+    assert parsed.content == node.content
+    assert parsed.metadata == node.metadata
+
+
+def test_edges_round_trip(tmp_path: Path) -> None:
+    edges = [
+        ParsedEdge(
+            source="exercises/squat",
+            target="conditions/knee",
+            edge_type="because_of",
+            weight=0.9,
+            content="meniscus",
+        ),
+    ]
+    (tmp_path / "edges.yaml").write_text(serialise_edges(edges), encoding="utf-8")
+    parsed = parse_edges(tmp_path / "edges.yaml", "exercises/squat")
+    assert len(parsed) == 1
+    assert parsed[0].target == "conditions/knee"
+    assert parsed[0].weight == 0.9
+    assert parsed[0].content == "meniscus"
+
+
+# ── importer on the fixture tree ───────────────────────────────────────────
+
+
+def test_import_fixture_tree() -> None:
+    store = GraphStore(":memory:")
+    source = FolderTreeSource(FIXTURE_TREE)
+    report = source.import_into(store)
+
+    assert report.nodes >= 7  # exercises/, bench-press, squat, rules/, prog, deload, cond, knee
+    assert store.get_node("exercises/squat") is not None
+    assert store.get_node("rules/progression") is not None
+
+    # Status metadata preserved from frontmatter
+    squat = store.get_node("exercises/squat")
+    assert squat is not None
+    assert squat.status == "avoided"
+
+    # Explicit edges
+    out = store.out_edges("exercises/squat", edge_types=["because_of"])
+    assert len(out) == 1
+    assert out[0].target == "conditions/knee-pain"
+
+
+def test_derived_part_of_edges() -> None:
+    store = GraphStore(":memory:")
+    source = FolderTreeSource(FIXTURE_TREE)
+    source.import_into(store)
+
+    # exercises/squat should have a derived part_of edge → exercises
+    part_of = store.out_edges("exercises/squat", edge_types=["part_of"])
+    assert len(part_of) == 1
+    assert part_of[0].target == "exercises"
+    assert part_of[0].metadata.get("derived") is True
+
+
+def test_import_rejects_edge_to_missing_target(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "readme.md").write_text("---\ntype: x\n---\nA", encoding="utf-8")
+    (tmp_path / "a" / "edges.yaml").write_text(
+        "edges:\n  - target: b\n    type: if_then\n", encoding="utf-8"
+    )
+    store = GraphStore(":memory:")
+    with pytest.raises(SourceError, match="target does not exist"):
+        FolderTreeSource(tmp_path).import_into(store)
+
+
+# ── exporter round-trip ────────────────────────────────────────────────────
+
+
+def test_export_then_reimport_is_stable(tmp_path: Path) -> None:
+    store1 = GraphStore(":memory:")
+    FolderTreeSource(FIXTURE_TREE).import_into(store1)
+
+    target = tmp_path / "out"
+    FolderTreeSource(target).export_from(store1)
+
+    store2 = GraphStore(":memory:")
+    FolderTreeSource(target).import_into(store2)
+
+    # Node counts match
+    assert store1.node_count() == store2.node_count()
+
+    # Every node in store1 appears in store2 with same metadata and content
+    for nid in store1.all_node_ids():
+        n1 = store1.get_node(nid)
+        n2 = store2.get_node(nid)
+        assert n2 is not None, f"missing {nid}"
+        assert n1 is not None
+        assert n1.content == n2.content
+        assert n1.metadata == n2.metadata
+
+    # Every explicit edge survives the round-trip
+    for nid in store1.all_node_ids():
+        explicit_before = sorted(
+            (e.target, e.type, e.weight)
+            for e in store1.out_edges(nid)
+            if not e.metadata.get("derived", False)
+        )
+        explicit_after = sorted(
+            (e.target, e.type, e.weight)
+            for e in store2.out_edges(nid)
+            if not e.metadata.get("derived", False)
+        )
+        assert explicit_before == explicit_after


### PR DESCRIPTION
## Summary

- Commits to a hierarchical folder tree as the canonical source of truth (ADR 0001)
- `FolderTreeSource` importer/exporter round-trips the graph store, synthesising `part_of` edges from parent folders
- Adds `ctx import` / `ctx export` CLI and a fixture tree for tests

## Why not Obsidian

Obsidian's wikilinks can't express typed, weighted, annotated edges. Its path-based identity renames silently. Its frontmatter is flat. The folder tree gives us git-native versioning of every weight update the feedback loop produces, stable ids mediated by `git mv`, and explicit edge metadata in `edges.yaml`. Obsidian can still read the tree as a plain vault if anyone wants that.

## Test plan

- [x] `pytest` — 32 tests pass (10 new for source module)
- [x] `ruff check` clean
- [x] Round-trip: import fixture tree → export to new path → re-import → nodes & explicit edges equal
- [x] CLI smoke: `ctx import fixtures/tree` → `ctx query "Why do I avoid squats?" --seed exercises/squat` reaches `conditions/knee-pain`
- [x] CLI smoke: `ctx query "Should I increase bench?" --seed exercises/bench-press` triggers rule chain closure and pulls `rules/deload` via `falls_back_to`

🤖 Generated with [Claude Code](https://claude.com/claude-code)