### PR TITLE
LLM-backed classifier with graceful fallback (closes #2)

### DIFF
--- a/src/context_engine/engine.py
+++ b/src/context_engine/engine.py
@@ -9,7 +9,7 @@ so tests can run without network access.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 from context_engine.classifier import Classifier, KeywordClassifier
@@ -49,6 +49,7 @@ class EngineResponse:
     logic_results: list[LogicResult]
     needed_widen: bool = False
     gap_flag: bool = False
+    warnings: list[str] = field(default_factory=list)
 
 
 class OfflineSynthesiser:

--- a/src/context_engine/llm_classifier.py
+++ b/src/context_engine/llm_classifier.py
@@ -1,0 +1,171 @@
+"""LLM-backed classifier.
+
+Drop-in replacement for KeywordClassifier that sends the query to Claude
+and asks for a structured (intent, focus) tuple plus any entity references
+the query names directly. Uses tool-call JSON mode for deterministic
+parsing. Falls through to KeywordClassifier on any failure — network
+error, invalid JSON, out-of-range enum values, or a missing Anthropic SDK.
+
+The LLM call latency and token usage are recorded on the classifier
+instance (last_latency_ms, last_input_tokens, last_output_tokens) so
+callers can read them after classify() returns. These fields are reset
+on every call.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from context_engine.classifier import Classifier, KeywordClassifier
+from context_engine.types import Focus, Intent, Query, QueryTuple
+
+_TOOL_SCHEMA: dict[str, Any] = {
+    "name": "classify_query",
+    "description": (
+        "Classify a natural-language query into an (intent, focus) tuple and extract "
+        "any entity names the query references directly."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "intent": {
+                "type": "string",
+                "enum": [e.value for e in Intent],
+                "description": "What the user wants: controls which pipeline components run.",
+            },
+            "focus": {
+                "type": "string",
+                "enum": [e.value for e in Focus],
+                "description": (
+                    "What kind of knowledge is needed: controls traversal edge priorities."
+                ),
+            },
+            "explicit_refs": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Entity names the query references directly, e.g. 'squats', 'bench press'. "
+                    "Empty list if the query contains no explicit entity references."
+                ),
+            },
+        },
+        "required": ["intent", "focus", "explicit_refs"],
+    },
+}
+
+_SYSTEM_PROMPT = """\
+You are a query classifier for a graph-based context retrieval engine.
+
+Given a natural-language query, determine:
+  - intent: what the user wants (retrieve, evaluate, compare, act, scan)
+  - focus: what kind of knowledge is needed (causal, procedural, temporal, attributive, conditional)
+  - explicit_refs: entity names the query names directly (e.g. "squats", "bench press")
+
+Intent definitions:
+  retrieve  — get information
+  evaluate  — assess state against rules
+  compare   — contrast two or more things
+  act       — determine what to do
+  scan      — aggregate or list across many entities
+
+Focus definitions:
+  causal      — why something is the case
+  procedural  — how something works or is done
+  temporal    — when something applies or triggers
+  attributive — what something is or has
+  conditional — whether criteria are met
+
+Call the classify_query tool with your answer. Do not add explanation outside the tool call.\
+"""
+
+
+class LLMClassifier:
+    """Classifier backed by Claude via structured tool-call output.
+
+    Falls through to ``KeywordClassifier`` on any failure. Records latency
+    and token usage on instance attributes after each call.
+    """
+
+    def __init__(
+        self,
+        client: Any | None = None,
+        model: str = "claude-sonnet-4-5",
+        fallback: Classifier | None = None,
+    ) -> None:
+        self.model = model
+        self.fallback: Classifier = fallback if fallback is not None else KeywordClassifier()
+
+        self._import_error: Exception | None = None
+        if client is None:
+            try:
+                import anthropic  # noqa: PLC0415
+
+                self._client: Any = anthropic.Anthropic()
+            except Exception as exc:  # noqa: BLE001
+                self._import_error = exc
+                self._client = None
+        else:
+            self._client = client
+
+        # Per-call metrics — reset at the start of every classify() call.
+        self.last_latency_ms: float = 0.0
+        self.last_input_tokens: int = 0
+        self.last_output_tokens: int = 0
+        self.last_warning: str | None = None
+        self.last_explicit_refs: list[str] = []
+
+    def classify(self, query: Query) -> QueryTuple:
+        """Classify *query* via LLM; fall back to KeywordClassifier on any error."""
+        # Reset per-call state.
+        self.last_latency_ms = 0.0
+        self.last_input_tokens = 0
+        self.last_output_tokens = 0
+        self.last_warning = None
+        self.last_explicit_refs = []
+
+        if self._import_error is not None:
+            self.last_warning = f"LLMClassifier fallback: {self._import_error}"
+            return self.fallback.classify(query)
+
+        try:
+            return self._call_llm(query)
+        except Exception as exc:  # noqa: BLE001
+            self.last_warning = f"LLMClassifier fallback: {exc}"
+            return self.fallback.classify(query)
+
+    def _call_llm(self, query: Query) -> QueryTuple:
+        t0 = time.perf_counter()
+        response = self._client.messages.create(
+            model=self.model,
+            max_tokens=256,
+            system=_SYSTEM_PROMPT,
+            tools=[_TOOL_SCHEMA],
+            tool_choice={"type": "tool", "name": "classify_query"},
+            messages=[{"role": "user", "content": query.text}],
+        )
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+        self.last_latency_ms = elapsed_ms
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            self.last_input_tokens = getattr(usage, "input_tokens", 0)
+            self.last_output_tokens = getattr(usage, "output_tokens", 0)
+
+        # Extract the tool_use block.
+        tool_block = next(
+            (block for block in response.content if getattr(block, "type", None) == "tool_use"),
+            None,
+        )
+        if tool_block is None:
+            raise ValueError("LLM response contained no tool_use block")
+
+        raw: dict[str, Any] = tool_block.input
+
+        # Validate enum values — raises ValueError on bad input, triggering fallback.
+        intent = Intent(raw["intent"])
+        focus = Focus(raw["focus"])
+
+        self.last_explicit_refs = list(raw.get("explicit_refs") or [])
+
+        return QueryTuple(intent=intent, focus=focus)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from context_engine.engine import ContextEngine
+from context_engine.engine import ContextEngine, EngineResponse
 from context_engine.store import GraphStore
-from context_engine.types import Query
+from context_engine.types import ContextSlice, Focus, Intent, Query, QueryTuple, TraversalStrategy
 
 
 def test_engine_answers_causal_query(store: GraphStore) -> None:
@@ -23,3 +23,14 @@ def test_engine_evaluates_progression(store: GraphStore) -> None:
     assert resp.logic_results, "evaluate intent must produce logic results"
     passed = any(r.passed for r in resp.logic_results)
     assert passed
+
+
+def test_engine_response_warnings_defaults_to_empty_list() -> None:
+    slice_ = ContextSlice(nodes=[], edges=[], seeds=[], strategy=TraversalStrategy())
+    resp = EngineResponse(
+        text="",
+        tuple_=QueryTuple(intent=Intent.RETRIEVE, focus=Focus.CAUSAL),
+        slice_=slice_,
+        logic_results=[],
+    )
+    assert resp.warnings == []

--- a/tests/test_llm_classifier.py
+++ b/tests/test_llm_classifier.py
@@ -1,0 +1,119 @@
+"""Tests for LLMClassifier.
+
+Covers happy-path parsing, malformed response fallback, exception fallback,
+and an integration smoke test (skipped without ANTHROPIC_API_KEY).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from context_engine.classifier import KeywordClassifier
+from context_engine.llm_classifier import LLMClassifier
+from context_engine.types import Focus, Intent, Query, QueryTuple
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_tool_use_block(input_dict: dict) -> MagicMock:
+    block = MagicMock()
+    block.type = "tool_use"
+    block.input = input_dict
+    return block
+
+
+def _make_response(input_dict: dict, input_tokens: int = 10, output_tokens: int = 5) -> MagicMock:
+    block = _make_tool_use_block(input_dict)
+    response = MagicMock()
+    response.content = [block]
+    response.usage.input_tokens = input_tokens
+    response.usage.output_tokens = output_tokens
+    return response
+
+
+def _make_client(response_or_exc) -> MagicMock:
+    """Return a fake Anthropic client whose messages.create() returns or raises."""
+    client = MagicMock()
+    if isinstance(response_or_exc, Exception):
+        client.messages.create.side_effect = response_or_exc
+    else:
+        client.messages.create.return_value = response_or_exc
+    return client
+
+
+# ── test 1: happy path ────────────────────────────────────────────────────────
+
+
+def test_happy_path_returns_correct_tuple() -> None:
+    """Mocked client returns valid tool_use; classifier parses and returns QueryTuple."""
+    response = _make_response(
+        {"intent": "retrieve", "focus": "causal", "explicit_refs": ["squats"]},
+        input_tokens=12,
+        output_tokens=8,
+    )
+    client = _make_client(response)
+    clf = LLMClassifier(client=client)
+
+    result = clf.classify(Query(text="Why do I avoid squats?"))
+
+    assert result == QueryTuple(intent=Intent.RETRIEVE, focus=Focus.CAUSAL)
+    assert clf.last_explicit_refs == ["squats"]
+    assert clf.last_warning is None
+    assert clf.last_input_tokens == 12
+    assert clf.last_output_tokens == 8
+    assert clf.last_latency_ms >= 0.0
+
+
+# ── test 2: malformed response falls back ─────────────────────────────────────
+
+
+def test_malformed_intent_falls_back_to_keyword_classifier() -> None:
+    """tool_use block with invalid intent value triggers fallback."""
+    response = _make_response({"intent": "bogus", "focus": "causal", "explicit_refs": []})
+    client = _make_client(response)
+    clf = LLMClassifier(client=client)
+
+    query = Query(text="Why do I avoid squats?")
+    result = clf.classify(query)
+
+    # Fallback should return what KeywordClassifier would return.
+    expected = KeywordClassifier().classify(query)
+    assert result == expected
+    assert clf.last_warning is not None
+    assert clf.last_warning.startswith("LLMClassifier fallback:")
+
+
+# ── test 3: network exception falls back ──────────────────────────────────────
+
+
+def test_exception_falls_back_and_records_warning() -> None:
+    """RuntimeError from messages.create triggers fallback with warning containing the message."""
+    client = _make_client(RuntimeError("network"))
+    clf = LLMClassifier(client=client)
+
+    query = Query(text="How do I progress overhead press?")
+    result = clf.classify(query)
+
+    expected = KeywordClassifier().classify(query)
+    assert result == expected
+    assert clf.last_warning is not None
+    assert "network" in clf.last_warning
+    assert clf.last_warning.startswith("LLMClassifier fallback:")
+
+
+# ── test 4: integration smoke ─────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set",
+)
+def test_integration_smoke() -> None:
+    """Real LLMClassifier with no explicit client classifies a causal query correctly."""
+    clf = LLMClassifier()
+    result = clf.classify(Query(text="Why do I avoid squats?"))
+    assert result.intent == Intent.RETRIEVE
+    assert result.focus == Focus.CAUSAL


### PR DESCRIPTION
## Summary

- New `LLMClassifier` — forced tool-call to Claude, returns structured `(intent, focus)` + extracted explicit_refs
- Graceful fallback chain: import error, network error, or invalid enum → fall through to `KeywordClassifier` and record `last_warning`
- Records per-call latency + token usage for future cost/quality analysis
- New `EngineResponse.warnings` field for surfacing fallback notices

## Scoping

Implemented in parallel with #3 via two subagents on separate worktrees. This PR touches only:
- `src/context_engine/llm_classifier.py` (new, 171 LOC)
- `src/context_engine/engine.py` (2-line edit: add `field` import + `warnings` field)
- `tests/test_llm_classifier.py` (new, 4 tests)
- `tests/test_engine.py` (+3 lines for warnings default)

## Test plan

- [x] 50 passed + 2 skipped (up from 46+1)
- [x] Mocked client: happy path, malformed JSON fallback, exception fallback
- [x] Real API integration test skipped without `ANTHROPIC_API_KEY`
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)