### PR TITLE
LLM synthesiser with gap detection and auto-feedback (closes #3)

### DIFF
--- a/src/context_engine/engine.py
+++ b/src/context_engine/engine.py
@@ -50,6 +50,9 @@ class EngineResponse:
     needed_widen: bool = False
     gap_flag: bool = False
     warnings: list[str] = field(default_factory=list)
+    used_node_ids: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    confidence: float = 1.0
 
 
 class OfflineSynthesiser:
@@ -86,6 +89,9 @@ class OfflineSynthesiser:
             tuple_=tuple_,
             slice_=slice_,
             logic_results=logic_results,
+            used_node_ids=[n.id for n in slice_.nodes],  # offline: assume all used
+            missing=[],
+            confidence=1.0,
         )
 
 
@@ -97,6 +103,7 @@ class ContextEngine:
         synthesiser: Synthesiser | None = None,
         embed_fn: Callable[[str], list[float]] | None = None,
         embedder: Embedder | None = None,
+        auto_feedback: bool = False,
     ) -> None:
         self.store = store
         self.classifier = classifier or KeywordClassifier()
@@ -108,6 +115,7 @@ class ContextEngine:
         self.traverser = Traverser(store)
         self.logic = LogicEngine()
         self.feedback = FeedbackApplier(store)
+        self.auto_feedback = auto_feedback
 
     def index_all(self) -> tuple[int, int]:
         """Backfill embeddings for every node that does not yet have one.
@@ -144,18 +152,53 @@ class ContextEngine:
         if tuple_.intent in (Intent.EVALUATE, Intent.ACT):
             logic_results = self.logic.evaluate(slice_)
 
-        # Gap detection: any logic result that flagged missing facts widens
-        # the traversal and retries once.
-        needed_widen = False
+        # Gap detection pass 1: any logic result that flagged missing facts
+        # widens the traversal and retries once.
+        needed_widen_logic = False
         if any(r.missing for r in logic_results):
-            needed_widen = True
-            wider = widen(strategy)
-            slice_ = self.traverser.traverse(wider, tuple_)
+            needed_widen_logic = True
+            wider_logic = widen(strategy)
+            slice_ = self.traverser.traverse(wider_logic, tuple_)
             logic_results = self.logic.evaluate(slice_)
 
         response = self.synthesiser.synthesise(query, tuple_, slice_, logic_results)
+
+        # Gap detection pass 2: synthesiser signals missing knowledge.
+        # Widen once more and re-synthesise if we haven't already widened twice.
+        needed_widen = needed_widen_logic
+        widen_count = 1 if needed_widen_logic else 0
+        if response.missing and widen_count < 2:
+            needed_widen = True
+            wider_synth = widen(strategy)
+            slice_ = self.traverser.traverse(wider_synth, tuple_)
+            if tuple_.intent in (Intent.EVALUATE, Intent.ACT):
+                logic_results = self.logic.evaluate(slice_)
+            response = self.synthesiser.synthesise(query, tuple_, slice_, logic_results)
+
         response.needed_widen = needed_widen
-        response.gap_flag = needed_widen
+        response.gap_flag = bool(response.missing) or needed_widen
+
+        if self.auto_feedback:
+            slice_node_ids = {n.id for n in response.slice_.nodes}
+            used_set = set(response.used_node_ids)
+            helpful_edge_ids = [
+                e.id for e in response.slice_.edges if e.target in used_set
+            ]
+            noisy_edge_ids = [
+                e.id
+                for e in response.slice_.edges
+                if e.target in slice_node_ids and e.target not in used_set
+            ]
+            signal = FeedbackSignal(
+                query_text=query.text,
+                used_node_ids=response.used_node_ids,
+                helpful_edge_ids=helpful_edge_ids,
+                noisy_edge_ids=noisy_edge_ids,
+                source="llm",
+                delta=0.5,
+            )
+            self.feedback.apply(signal)
+
         return response
 
     def record_feedback(self, signal: FeedbackSignal) -> dict[str, float]:

--- a/src/context_engine/llm_synthesiser.py
+++ b/src/context_engine/llm_synthesiser.py
@@ -1,0 +1,192 @@
+"""LLM-backed synthesiser with gap detection.
+
+Asks Claude to answer the query using only the provided slice. The model
+is required to return a structured JSON payload via tool-call mode listing:
+
+  - answer         — the natural-language response
+  - used_node_ids  — ids it actually referenced (drives the feedback loop)
+  - missing        — free-text gaps that widen() should try to fill
+  - confidence     — 0.0-1.0 self-reported confidence
+
+On any parse failure or client error, returns an EngineResponse that
+wraps OfflineSynthesiser.synthesise() and records the failure reason.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from context_engine.engine import EngineResponse, OfflineSynthesiser, Synthesiser
+from context_engine.logic import LogicResult
+from context_engine.types import ContextSlice, Query, QueryTuple
+
+_SYSTEM_PROMPT = (
+    "You are a precise assistant. Answer the user's question using ONLY the provided "
+    "knowledge fragments. If critical information is missing, list it under 'missing'. "
+    "Always call the answer tool."
+)
+
+_ANSWER_TOOL: dict[str, Any] = {
+    "name": "answer",
+    "description": (
+        "Return a structured answer. Use only the knowledge fragments provided. "
+        "List node ids you referenced in used_node_ids. List knowledge gaps in missing."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "answer": {
+                "type": "string",
+                "description": "The natural-language answer to the user's question.",
+            },
+            "used_node_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "IDs of knowledge fragments that informed the answer.",
+            },
+            "missing": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Free-text descriptions of knowledge that was needed but absent "
+                    "from the provided fragments."
+                ),
+            },
+            "confidence": {
+                "type": "number",
+                "description": "Self-reported confidence between 0.0 and 1.0.",
+            },
+        },
+        "required": ["answer", "used_node_ids", "missing", "confidence"],
+    },
+}
+
+
+def _build_user_message(
+    query: Query,
+    tuple_: QueryTuple,
+    slice_: ContextSlice,
+    logic_results: list[LogicResult],
+) -> str:
+    parts: list[str] = []
+    parts.append(f"Question: {query.text}")
+    parts.append(f"Query tuple: {tuple_}")
+    parts.append("")
+
+    if slice_.nodes:
+        parts.append("Knowledge fragments:")
+        for i, node in enumerate(slice_.nodes, start=1):
+            node_type = node.type or "node"
+            parts.append(f"  {i}. [NODE id={node.id} type={node_type}] {node.content}")
+    else:
+        parts.append("Knowledge fragments: (none)")
+
+    if logic_results:
+        parts.append("")
+        parts.append("Logic evaluation results:")
+        for r in logic_results:
+            parts.append(
+                f"  [LOGIC rule_id={r.rule_id} passed={r.passed} explanation={r.explanation}]"
+            )
+
+    return "\n".join(parts)
+
+
+class LLMSynthesiser:
+    """Production synthesiser backed by Claude via the Anthropic SDK.
+
+    Parameters
+    ----------
+    client:
+        An ``anthropic.Anthropic`` client instance. If ``None``, one is
+        constructed lazily on first use. If the import or construction fails,
+        all calls fall through to ``fallback``.
+    model:
+        The Claude model identifier to use.
+    fallback:
+        Synthesiser to use when the LLM call fails. Defaults to
+        ``OfflineSynthesiser()``.
+    """
+
+    def __init__(
+        self,
+        client: Any | None = None,
+        model: str = "claude-sonnet-4-5",
+        fallback: Synthesiser | None = None,
+    ) -> None:
+        self._client = client
+        self.model = model
+        self.fallback = fallback if fallback is not None else OfflineSynthesiser()
+        self._client_error: str | None = None
+
+        if client is None:
+            try:
+                import anthropic  # noqa: PLC0415
+
+                self._client = anthropic.Anthropic()
+            except Exception as exc:  # pragma: no cover
+                self._client_error = str(exc)
+
+    def synthesise(
+        self,
+        query: Query,
+        tuple_: QueryTuple,
+        slice_: ContextSlice,
+        logic_results: list[LogicResult],
+    ) -> EngineResponse:
+        """Synthesise a response, falling back to offline mode on any error."""
+        if self._client is None:
+            fallback_resp = self.fallback.synthesise(query, tuple_, slice_, logic_results)
+            if self._client_error:
+                fallback_resp.missing = [
+                    f"LLM client unavailable: {self._client_error}"
+                ]
+            return fallback_resp
+
+        user_message = _build_user_message(query, tuple_, slice_, logic_results)
+
+        try:
+            response = self._client.messages.create(
+                model=self.model,
+                max_tokens=1024,
+                system=_SYSTEM_PROMPT,
+                tools=[_ANSWER_TOOL],
+                tool_choice={"type": "tool", "name": "answer"},
+                messages=[{"role": "user", "content": user_message}],
+            )
+        except Exception as exc:
+            fallback_resp = self.fallback.synthesise(query, tuple_, slice_, logic_results)
+            fallback_resp.missing = [f"LLM call failed: {exc}"]
+            return fallback_resp
+
+        # Extract the tool_use block.
+        tool_input: dict[str, Any] | None = None
+        for block in response.content:
+            if hasattr(block, "type") and block.type == "tool_use" and block.name == "answer":
+                tool_input = block.input
+                break
+
+        if tool_input is None:
+            fallback_resp = self.fallback.synthesise(query, tuple_, slice_, logic_results)
+            fallback_resp.missing = ["LLM did not call the answer tool"]
+            return fallback_resp
+
+        try:
+            answer_text = str(tool_input["answer"])
+            used_node_ids = [str(x) for x in tool_input.get("used_node_ids", [])]
+            missing = [str(x) for x in tool_input.get("missing", [])]
+            confidence = float(tool_input.get("confidence", 1.0))
+        except (KeyError, TypeError, ValueError) as exc:
+            fallback_resp = self.fallback.synthesise(query, tuple_, slice_, logic_results)
+            fallback_resp.missing = [f"LLM response parse error: {exc}"]
+            return fallback_resp
+
+        return EngineResponse(
+            text=answer_text,
+            tuple_=tuple_,
+            slice_=slice_,
+            logic_results=logic_results,
+            used_node_ids=used_node_ids,
+            missing=missing,
+            confidence=confidence,
+        )

--- a/tests/test_llm_synthesiser.py
+++ b/tests/test_llm_synthesiser.py
@@ -1,0 +1,195 @@
+"""Tests for LLMSynthesiser and the gap-detection / auto-feedback paths in ContextEngine."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from context_engine.engine import ContextEngine, EngineResponse
+from context_engine.llm_synthesiser import LLMSynthesiser
+from context_engine.logic import LogicResult
+from context_engine.store import GraphStore
+from context_engine.types import ContextSlice, Query, QueryTuple, TraversalStrategy
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _empty_slice() -> ContextSlice:
+    return ContextSlice(
+        nodes=[],
+        edges=[],
+        seeds=[],
+        strategy=TraversalStrategy(),
+    )
+
+
+def _make_tool_use_block(data: dict[str, Any]) -> MagicMock:
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = "answer"
+    block.input = data
+    return block
+
+
+def _make_client_response(tool_input: dict[str, Any]) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [_make_tool_use_block(tool_input)]
+    return msg
+
+
+# ── test 1: happy path with mocked client ──────────────────────────────────────
+
+
+def test_llm_synthesiser_happy_path() -> None:
+    """Mocked client returns a valid tool_use block; EngineResponse fields are set."""
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _make_client_response(
+        {
+            "answer": "You should increase bench weight.",
+            "used_node_ids": ["bench", "bench_obs_4"],
+            "missing": [],
+            "confidence": 0.9,
+        }
+    )
+
+    synth = LLMSynthesiser(client=fake_client, model="claude-test")
+    query = Query(text="Should I increase bench weight?", explicit_refs=["bench"])
+    qt = QueryTuple(intent="evaluate", focus="conditional")  # type: ignore[arg-type]
+    lr = LogicResult(
+        rule_id="progression_rule", passed=True, explanation="threshold met", missing=[]
+    )
+
+    resp = synth.synthesise(query, qt, _empty_slice(), [lr])
+
+    assert resp.text == "You should increase bench weight."
+    assert resp.used_node_ids == ["bench", "bench_obs_4"]
+    assert resp.missing == []
+    assert abs(resp.confidence - 0.9) < 1e-9
+    assert fake_client.messages.create.called
+
+
+# ── test 2: missing field triggers widen in ContextEngine ─────────────────────
+
+
+class _TwoPassSynthesiser:
+    """Returns `missing` on the first call, empty on the second."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def synthesise(
+        self,
+        query: Query,
+        tuple_: QueryTuple,
+        slice_: ContextSlice,
+        logic_results: list[LogicResult],
+    ) -> EngineResponse:
+        self.call_count += 1
+        if self.call_count == 1:
+            return EngineResponse(
+                text="I need more context.",
+                tuple_=tuple_,
+                slice_=slice_,
+                logic_results=logic_results,
+                used_node_ids=[],
+                missing=["progression rule was not in context"],
+                confidence=0.3,
+            )
+        return EngineResponse(
+            text="You should increase bench weight.",
+            tuple_=tuple_,
+            slice_=slice_,
+            logic_results=logic_results,
+            used_node_ids=["bench"],
+            missing=[],
+            confidence=0.9,
+        )
+
+
+def test_missing_field_triggers_widen(store: GraphStore) -> None:
+    """Engine widens and re-synthesises when synthesiser reports missing knowledge."""
+    synth = _TwoPassSynthesiser()
+    engine = ContextEngine(store, synthesiser=synth)  # type: ignore[arg-type]
+
+    resp = engine.answer(
+        Query(text="Should I increase bench weight?", explicit_refs=["bench"])
+    )
+
+    assert synth.call_count >= 2, "engine must synthesise at least twice on gap"
+    assert resp.needed_widen is True
+    assert resp.text == "You should increase bench weight."
+
+
+# ── test 3: auto_feedback updates edge weights ─────────────────────────────────
+
+
+class _FixedSynthesiser:
+    """Always reports progression_rule as the only used node."""
+
+    def synthesise(
+        self,
+        query: Query,
+        tuple_: QueryTuple,
+        slice_: ContextSlice,
+        logic_results: list[LogicResult],
+    ) -> EngineResponse:
+        return EngineResponse(
+            text="Bench result.",
+            tuple_=tuple_,
+            slice_=slice_,
+            logic_results=logic_results,
+            used_node_ids=["progression_rule"],
+            missing=[],
+            confidence=1.0,
+        )
+
+
+def test_auto_feedback_updates_weights(store: GraphStore) -> None:
+    """With auto_feedback=True, edges whose target is used get their weight updated.
+
+    The bench → progression_rule (if_then) edge should be treated as helpful
+    because progression_rule is in used_node_ids. Its weight must change.
+    """
+    engine = ContextEngine(
+        store,
+        synthesiser=_FixedSynthesiser(),  # type: ignore[arg-type]
+        auto_feedback=True,
+    )
+
+    # The if_then edge from bench → progression_rule will appear in the slice
+    # when querying with explicit_refs=["bench"].
+    candidate_edges = [
+        e for e in store.out_edges("bench") if e.target == "progression_rule"
+    ]
+    assert candidate_edges, "test fixture must have bench → progression_rule edge"
+    edge = candidate_edges[0]
+    before = edge.weight
+
+    engine.answer(Query(text="Should I increase bench weight?", explicit_refs=["bench"]))
+
+    refreshed = store.get_edge(edge.id)
+    assert refreshed is not None
+    # The edge targets progression_rule which is in used_node_ids → helpful → weight goes up.
+    assert refreshed.weight != before, "weight must change after auto_feedback"
+
+
+# ── test 4: integration smoke — skipped without API key ───────────────────────
+
+
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — skipping live LLM test",
+)
+def test_llm_synthesiser_integration_smoke() -> None:
+    """Build a real LLMSynthesiser and run a tiny slice through it."""
+    synth = LLMSynthesiser()
+    query = Query(text="What is bench press?", explicit_refs=["bench"])
+    qt = QueryTuple(intent="retrieve", focus="attributive")  # type: ignore[arg-type]
+    resp = synth.synthesise(query, qt, _empty_slice(), [])
+    assert isinstance(resp.text, str)
+    assert len(resp.text) > 0
+    assert isinstance(resp.confidence, float)
+    assert 0.0 <= resp.confidence <= 1.0


### PR DESCRIPTION
## Summary

- New `LLMSynthesiser` — forced tool-call to Claude, returns structured `{answer, used_node_ids, missing, confidence}`
- `ContextEngine.answer()` now runs a second widen pass when the synthesiser flags `missing` knowledge (capped at 2 widens total)
- New `auto_feedback: bool = False` flag: when enabled, derives a `FeedbackSignal` from used vs. unused slice edges and applies it after every answer
- `EngineResponse` gains `used_node_ids`, `missing`, `confidence` (all with safe defaults so the `OfflineSynthesiser` path is unchanged)

## Scoping

Implemented in parallel with #2 via a separate subagent on an isolated worktree. A trivial merge conflict in `EngineResponse` field list was resolved by the orchestrator — both `warnings` (from #2) and `used_node_ids`/`missing`/`confidence` (from #3) coexist.

## Test plan

- [x] 53 passed + 3 skipped (up from 50+2 after #2 merged)
- [x] Mocked synthesiser happy path
- [x] Widen-on-gap path: fake synthesiser returns `missing` on first call → engine widens and re-synthesises
- [x] `auto_feedback=True` verified by edge weights changing after answer
- [x] Real API integration test skipped without `ANTHROPIC_API_KEY`
- [x] `ruff check` clean
- [x] Rebased cleanly onto main after #2 landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)