### PR TITLE
Progressive widen heuristic with stats and strategy downgrade (closes #6)

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -151,6 +151,29 @@ Phased, each phase produces a runnable system that passes its own tests.
 - Tests: 10 new tests (8 in `test_strategy.py`, 1 in `test_feedback.py`,
   1 in `test_engine.py`); full suite 69 passed + 3 skipped
 
+## Phase 13 — progressive widen heuristic ✅
+
+- `widen()` in `strategy.py` gains a `level` parameter (default 1 for
+  backward compatibility):
+  - level 0: no-op
+  - level 1: 2× budget, +1 depth, weight_floor -= 0.1, edge_types preserved
+  - level 2: 4× budget, +2 depth, weight_floor = 0.0, edge_types cleared
+  - level ≥ 3: clamped to level 2
+  - Widen applied to the original strategy; not compounding
+- `StrategyResolver.downgrade(tuple_)`: permanently bumps budget (×1.5, cap 200),
+  depth (+1, cap 10), weight_floor (-0.05); increments `metadata.downgrade_count`
+- `ContextEngine.answer()` unified widen loop: synthesiser called at each widen
+  level; breaks on first gap-free response or on reaching MAX_WIDEN_LEVEL
+- `ContextEngine.__init__` gains `downgrade_threshold` parameter (default 3)
+- Prometheus-style `engine.stats` dict: `queries_total`, `widens_level_1`,
+  `widens_level_2`, `strategy_downgrades`
+- Signature-level failure tracking via `_signature_failures`; after
+  `downgrade_threshold` max-widen failures on the same (seeds, intent, focus),
+  the strategy node is permanently widened via `downgrade()`
+- Tests: 6 new strategy tests (widen levels 0/1/2/clamp, downgrade, downgrade
+  caps) + 3 new engine tests (three-tier progression, no-widen success,
+  downgrade-fires-after-threshold); full suite 78 passed + 3 skipped
+
 ## Next (beyond v0.1)
 
 1. **LLM classifier** — drop-in replacement for `KeywordClassifier`, uses

--- a/src/context_engine/engine.py
+++ b/src/context_engine/engine.py
@@ -104,6 +104,7 @@ class ContextEngine:
         embed_fn: Callable[[str], list[float]] | None = None,
         embedder: Embedder | None = None,
         auto_feedback: bool = False,
+        downgrade_threshold: int = 3,
     ) -> None:
         self.store = store
         self.classifier = classifier or KeywordClassifier()
@@ -117,6 +118,14 @@ class ContextEngine:
         self.logic = LogicEngine()
         self.feedback = FeedbackApplier(store, strategies=self.strategies)
         self.auto_feedback = auto_feedback
+        self.downgrade_threshold = downgrade_threshold
+        self._signature_failures: dict[tuple, int] = {}
+        self.stats: dict[str, int] = {
+            "queries_total": 0,
+            "widens_level_1": 0,
+            "widens_level_2": 0,
+            "strategy_downgrades": 0,
+        }
 
     def index_all(self) -> tuple[int, int]:
         """Backfill embeddings for every node that does not yet have one.
@@ -139,67 +148,99 @@ class ContextEngine:
             indexed += 1
         return indexed, already_had
 
+    def _signature(self, seeds: list[str], tuple_: QueryTuple) -> tuple:
+        """Return a hashable identifier for the (seeds, tuple) pair."""
+        return (frozenset(seeds), tuple_.intent.value, tuple_.focus.value)
+
+    def _emit_auto_feedback(
+        self, tuple_: QueryTuple, response: EngineResponse
+    ) -> None:
+        slice_node_ids = {n.id for n in response.slice_.nodes}
+        used_set = set(response.used_node_ids)
+        helpful_edge_ids = [
+            e.id for e in response.slice_.edges if e.target in used_set
+        ]
+        noisy_edge_ids = [
+            e.id
+            for e in response.slice_.edges
+            if e.target in slice_node_ids and e.target not in used_set
+        ]
+        signal = FeedbackSignal(
+            query_text="",
+            used_node_ids=response.used_node_ids,
+            helpful_edge_ids=helpful_edge_ids,
+            noisy_edge_ids=noisy_edge_ids,
+            source="llm",
+            delta=0.5,
+            query_tuple=tuple_,
+        )
+        self.feedback.apply(signal)
+
     def answer(
         self,
         query: Query,
         metadata_filter: dict[str, object] | None = None,
     ) -> EngineResponse:
+        self.stats["queries_total"] += 1
+
         tuple_ = self.classifier.classify(query)
         seeds = self.seeds.select(query, metadata_filter=metadata_filter)
-        strategy = self.strategies.resolve(tuple_, seeds=seeds)
-        slice_ = self.traverser.traverse(strategy, tuple_)
+        original_strategy = self.strategies.resolve(tuple_, seeds=seeds)
+        signature = self._signature(seeds, tuple_)
 
-        logic_results: list[LogicResult] = []
-        if tuple_.intent in (Intent.EVALUATE, Intent.ACT):
-            logic_results = self.logic.evaluate(slice_)
+        MAX_WIDEN_LEVEL = 2
+        widen_level = 0
+        needed_widen = False
+        gap_flag = False
+        had_gap = False
 
-        # Gap detection pass 1: any logic result that flagged missing facts
-        # widens the traversal and retries once.
-        needed_widen_logic = False
-        if any(r.missing for r in logic_results):
-            needed_widen_logic = True
-            wider_logic = widen(strategy)
-            slice_ = self.traverser.traverse(wider_logic, tuple_)
-            logic_results = self.logic.evaluate(slice_)
+        while True:
+            strategy = (
+                original_strategy
+                if widen_level == 0
+                else widen(original_strategy, level=widen_level)
+            )
+            slice_ = self.traverser.traverse(strategy, tuple_)
 
-        response = self.synthesiser.synthesise(query, tuple_, slice_, logic_results)
-
-        # Gap detection pass 2: synthesiser signals missing knowledge.
-        # Widen once more and re-synthesise if we haven't already widened twice.
-        needed_widen = needed_widen_logic
-        widen_count = 1 if needed_widen_logic else 0
-        if response.missing and widen_count < 2:
-            needed_widen = True
-            wider_synth = widen(strategy)
-            slice_ = self.traverser.traverse(wider_synth, tuple_)
+            logic_results: list[LogicResult] = []
             if tuple_.intent in (Intent.EVALUATE, Intent.ACT):
                 logic_results = self.logic.evaluate(slice_)
+
             response = self.synthesiser.synthesise(query, tuple_, slice_, logic_results)
 
+            logic_gap = any(r.missing for r in logic_results)
+            synth_gap = bool(response.missing)
+            had_gap = logic_gap or synth_gap
+
+            if not had_gap:
+                break
+
+            if widen_level >= MAX_WIDEN_LEVEL:
+                gap_flag = True
+                needed_widen = True
+                break
+
+            widen_level += 1
+            needed_widen = True
+            self.stats[f"widens_level_{widen_level}"] += 1
+
+        # Track signature-level failures for strategy downgrade.
+        if widen_level >= MAX_WIDEN_LEVEL and had_gap:
+            self._signature_failures[signature] = (
+                self._signature_failures.get(signature, 0) + 1
+            )
+            if self._signature_failures[signature] >= self.downgrade_threshold:
+                self.strategies.downgrade(tuple_)
+                self.stats["strategy_downgrades"] += 1
+                self._signature_failures[signature] = 0
+        elif not had_gap:
+            self._signature_failures.pop(signature, None)
+
         response.needed_widen = needed_widen
-        response.gap_flag = bool(response.missing) or needed_widen
+        response.gap_flag = gap_flag
 
         if self.auto_feedback:
-            slice_node_ids = {n.id for n in response.slice_.nodes}
-            used_set = set(response.used_node_ids)
-            helpful_edge_ids = [
-                e.id for e in response.slice_.edges if e.target in used_set
-            ]
-            noisy_edge_ids = [
-                e.id
-                for e in response.slice_.edges
-                if e.target in slice_node_ids and e.target not in used_set
-            ]
-            signal = FeedbackSignal(
-                query_text=query.text,
-                used_node_ids=response.used_node_ids,
-                helpful_edge_ids=helpful_edge_ids,
-                noisy_edge_ids=noisy_edge_ids,
-                source="llm",
-                delta=0.5,
-                query_tuple=tuple_,
-            )
-            self.feedback.apply(signal)
+            self._emit_auto_feedback(tuple_, response)
 
         return response
 

--- a/src/context_engine/strategy.py
+++ b/src/context_engine/strategy.py
@@ -203,6 +203,40 @@ class StrategyResolver:
             preserve_rule_chains=content.get("preserve_rule_chains", True),
         )
 
+    # ── downgrade ────────────────────────────────────────────────────────────
+
+    def downgrade(self, tuple_: QueryTuple) -> None:
+        """Mark the strategy for *tuple_* as underpowered.
+
+        Permanently bumps the stored strategy's budget, depth, and weight_floor
+        so future queries of the same shape start wider.  No-op if the strategy
+        node does not exist.
+
+        Caps: budget ≤ 200, depth ≤ 10.
+        """
+        node = self.get_strategy_node(tuple_)
+        if node is None:
+            return
+
+        meta = dict(node.metadata)
+        content = json.loads(node.content)
+
+        budget = min(int(content.get("budget", 20) * 1.5), 200)
+        depth = min(content.get("depth", 3) + 1, 10)
+        weight_floor = max(0.0, content.get("weight_floor", 0.2) - 0.05)
+
+        content["budget"] = budget
+        content["depth"] = depth
+        content["weight_floor"] = weight_floor
+
+        meta["downgrade_count"] = int(meta.get("downgrade_count", 0)) + 1
+
+        self.store.upsert_node(
+            content=json.dumps(content),
+            metadata=meta,
+            node_id=self.get_strategy_node_id(tuple_),
+        )
+
     # ── feedback ─────────────────────────────────────────────────────────────
 
     def record_success(
@@ -274,13 +308,36 @@ class StrategyResolver:
         )
 
 
-def widen(strategy: TraversalStrategy) -> TraversalStrategy:
-    """Escape hatch for repeated gap-detection failures."""
+def widen(strategy: TraversalStrategy, level: int = 1) -> TraversalStrategy:
+    """Escape hatch for repeated gap-detection failures.
+
+    Widen is always applied to the *original* strategy — callers must pass the
+    desired level rather than chaining calls.
+
+    - ``level=0`` — no-op; returns *strategy* unchanged.
+    - ``level=1`` — 2× budget, +1 depth, weight_floor decreased by 0.1 (min 0.0),
+      edge_types preserved.
+    - ``level=2`` — 4× budget, +2 depth, weight_floor = 0.0, edge_types cleared
+      (no filter).
+    - ``level >= 3`` — clamped to level 2.
+    """
+    if level <= 0:
+        return strategy
+    level = min(level, 2)
+    if level == 1:
+        return strategy.model_copy(
+            update={
+                "budget": strategy.budget * 2,
+                "depth": strategy.depth + 1,
+                "weight_floor": max(0.0, strategy.weight_floor - 0.1),
+            }
+        )
+    # level == 2: full widen, no filter
     return strategy.model_copy(
         update={
-            "budget": strategy.budget * 2,
-            "depth": strategy.depth + 1,
-            "weight_floor": max(0.0, strategy.weight_floor - 0.1),
-            "edge_types": [],  # remove the filter entirely
+            "budget": strategy.budget * 4,
+            "depth": strategy.depth + 2,
+            "weight_floor": 0.0,
+            "edge_types": [],
         }
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from context_engine.engine import ContextEngine, EngineResponse
+from context_engine.logic import LogicResult
 from context_engine.store import GraphStore
 from context_engine.types import ContextSlice, Focus, Intent, Query, QueryTuple, TraversalStrategy
 
@@ -44,3 +45,95 @@ def test_engine_response_warnings_defaults_to_empty_list() -> None:
         logic_results=[],
     )
     assert resp.warnings == []
+
+
+# ── progressive widen ─────────────────────────────────────────────────────────
+
+
+class _AlwaysMissingSynthesiser:
+    """Synthesiser that always reports missing knowledge."""
+
+    def synthesise(
+        self,
+        query: Query,
+        tuple_: QueryTuple,
+        slice_: ContextSlice,
+        logic_results: list[LogicResult],
+    ) -> EngineResponse:
+        return EngineResponse(
+            text="I need more context.",
+            tuple_=tuple_,
+            slice_=slice_,
+            logic_results=logic_results,
+            used_node_ids=[],
+            missing=["always"],
+            confidence=0.1,
+        )
+
+
+class _AlwaysOkSynthesiser:
+    """Synthesiser that never reports missing knowledge."""
+
+    def synthesise(
+        self,
+        query: Query,
+        tuple_: QueryTuple,
+        slice_: ContextSlice,
+        logic_results: list[LogicResult],
+    ) -> EngineResponse:
+        return EngineResponse(
+            text="All good.",
+            tuple_=tuple_,
+            slice_=slice_,
+            logic_results=logic_results,
+            used_node_ids=[],
+            missing=[],
+            confidence=1.0,
+        )
+
+
+def test_three_tier_widen_progression(store: GraphStore) -> None:
+    """Engine escalates through all widen levels and sets stats + flags correctly."""
+    engine = ContextEngine(store, synthesiser=_AlwaysMissingSynthesiser())  # type: ignore[arg-type]
+
+    resp = engine.answer(Query(text="Why avoid squats?", explicit_refs=["squat"]))
+
+    assert resp.needed_widen is True
+    assert resp.gap_flag is True
+    assert engine.stats["queries_total"] == 1
+    assert engine.stats["widens_level_1"] == 1
+    assert engine.stats["widens_level_2"] == 1
+
+
+def test_no_widen_on_successful_answer(store: GraphStore) -> None:
+    """When synthesiser succeeds immediately, no widen counters are incremented."""
+    engine = ContextEngine(store, synthesiser=_AlwaysOkSynthesiser())  # type: ignore[arg-type]
+
+    resp = engine.answer(Query(text="Why avoid squats?", explicit_refs=["squat"]))
+
+    assert resp.needed_widen is False
+    assert resp.gap_flag is False
+    assert engine.stats["widens_level_1"] == 0
+    assert engine.stats["widens_level_2"] == 0
+
+
+def test_strategy_downgrade_fires_after_threshold(store: GraphStore) -> None:
+    """After threshold repeated max-widen failures, downgrade fires and mutates node."""
+    engine = ContextEngine(
+        store,
+        synthesiser=_AlwaysMissingSynthesiser(),  # type: ignore[arg-type]
+        downgrade_threshold=2,
+    )
+    q = Query(text="Why avoid squats?", explicit_refs=["squat"])
+
+    engine.answer(q)
+    assert engine.stats["strategy_downgrades"] == 0
+
+    engine.answer(q)
+    assert engine.stats["strategy_downgrades"] == 1
+
+    # The strategy node should have been mutated.
+    tuple_ = engine.classifier.classify(q)
+    node = engine.strategies.get_strategy_node(tuple_)
+    assert node is not None
+    assert node.metadata.get("downgrade_count", 0) == 1

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from context_engine.store import GraphStore
-from context_engine.strategy import StrategyResolver, strategy_for
-from context_engine.types import Focus, Intent, QueryTuple
+from context_engine.strategy import StrategyResolver, strategy_for, widen
+from context_engine.types import Focus, Intent, QueryTuple, TraversalStrategy
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -152,3 +154,99 @@ def test_resolve_orders_edge_types_by_score() -> None:
     strategy = resolver.resolve(t, seeds=[])
     types = strategy.edge_types
     assert types.index("if_then") < types.index("threshold")
+
+
+# ── widen levels ──────────────────────────────────────────────────────────────
+
+
+def _base_strategy() -> TraversalStrategy:
+    return TraversalStrategy(
+        budget=20,
+        depth=3,
+        weight_floor=0.3,
+        edge_types=["if_then", "threshold"],
+    )
+
+
+def test_widen_level_0_is_noop() -> None:
+    """widen(s, level=0) returns an identical strategy."""
+    s = _base_strategy()
+    result = widen(s, level=0)
+    assert result.budget == s.budget
+    assert result.depth == s.depth
+    assert result.weight_floor == s.weight_floor
+    assert result.edge_types == s.edge_types
+
+
+def test_widen_level_1_doubles_budget_relaxes_floor() -> None:
+    """widen(s, level=1) doubles budget, increments depth, decreases weight_floor."""
+    s = _base_strategy()
+    result = widen(s, level=1)
+    assert result.budget == 40
+    assert result.depth == 4
+    assert result.weight_floor == pytest.approx(0.2)
+    assert result.edge_types == s.edge_types  # preserved
+
+
+def test_widen_level_2_clears_filter_full_widen() -> None:
+    """widen(s, level=2) applies 4× budget, +2 depth, weight_floor=0.0, no filter."""
+    s = _base_strategy()
+    result = widen(s, level=2)
+    assert result.budget == 80
+    assert result.depth == 5
+    assert result.weight_floor == 0.0
+    assert result.edge_types == []
+
+
+def test_widen_level_clamps_at_2() -> None:
+    """widen(s, level=5) behaves identically to widen(s, level=2)."""
+    s = _base_strategy()
+    assert widen(s, level=5).budget == widen(s, level=2).budget
+    assert widen(s, level=5).depth == widen(s, level=2).depth
+    assert widen(s, level=5).edge_types == []
+
+
+# ── StrategyResolver.downgrade ────────────────────────────────────────────────
+
+
+def test_downgrade_bumps_stored_params() -> None:
+    """downgrade() increases budget/depth and decreases weight_floor; sets downgrade_count."""
+    store = GraphStore(":memory:")
+    resolver = StrategyResolver(store)
+    resolver.bootstrap()
+
+    t = _tuple(Intent.EVALUATE, Focus.CONDITIONAL)
+    node_before = resolver.get_strategy_node(t)
+    assert node_before is not None
+    content_before = json.loads(node_before.content)
+    budget_before = content_before["budget"]
+    depth_before = content_before["depth"]
+    floor_before = content_before["weight_floor"]
+
+    resolver.downgrade(t)
+
+    node_after = resolver.get_strategy_node(t)
+    assert node_after is not None
+    content_after = json.loads(node_after.content)
+
+    assert content_after["budget"] > budget_before
+    assert content_after["depth"] > depth_before
+    assert content_after["weight_floor"] < floor_before
+    assert node_after.metadata["downgrade_count"] == 1
+
+
+def test_downgrade_caps_budget_and_depth() -> None:
+    """Repeated downgrade() calls never exceed budget=200 or depth=10."""
+    store = GraphStore(":memory:")
+    resolver = StrategyResolver(store)
+    resolver.bootstrap()
+
+    t = _tuple(Intent.EVALUATE, Focus.CONDITIONAL)
+    for _ in range(10):
+        resolver.downgrade(t)
+
+    node = resolver.get_strategy_node(t)
+    assert node is not None
+    content = json.loads(node.content)
+    assert content["budget"] <= 200
+    assert content["depth"] <= 10


### PR DESCRIPTION
## Summary

- `widen()` now takes a `level` parameter: 0 = noop, 1 = 2× budget +1 depth (preserves filter), 2 = 4× budget +2 depth + no filter + weight_floor=0. Level clamps at 2. Default level=1 keeps all existing callers working unchanged.
- `ContextEngine.answer()` unifies the two previous widen paths (logic-missing + synthesiser-missing) into a single level-driven loop that traverses, evaluates logic, and synthesises at each level until the gap closes or max level is reached.
- New `StrategyResolver.downgrade(tuple_)` permanently bumps the stored strategy's budget (×1.5, cap 200), depth (+1, cap 10), and weight_floor (−0.05, floor 0.0) plus a `downgrade_count` metadata field.
- `ContextEngine` now tracks per-signature `(frozenset(seeds), intent, focus)` failure counts; after `downgrade_threshold` (default 3) consecutive max-widen failures on the same shape, it dispatches a downgrade and resets the counter.
- New `engine.stats` dict: `queries_total`, `widens_level_1`, `widens_level_2`, `strategy_downgrades` — Prometheus-style counters the orchestrator or a future dashboard can scrape.

## Scoping

Single subagent on an isolated worktree. Files touched:

| File | Change |
|---|---|
| `src/context_engine/strategy.py` | `widen` refactor + `StrategyResolver.downgrade()` |
| `src/context_engine/engine.py` | Unified widen loop, stats dict, signature tracking, downgrade dispatch |
| `tests/test_strategy.py` | +6 tests (widen levels, cap, downgrade, downgrade cap) |
| `tests/test_engine.py` | +3 tests (three-tier progression, no-widen happy path, downgrade threshold) |
| `docs/implementation-plan.md` | Phase 13 entry |

No other files touched. `feedback.py`, `traversal.py`, `types.py`, `llm_synthesiser.py`, all cli / store / seeds / source modules intentionally untouched.

## Test plan

- [x] **78 passed + 3 skipped** (up from 69+3, +9 new tests)
- [x] `ruff check` clean
- [x] `widen()` level smoke test: `level=0` noop, `level=1` → `40/4`, `level=2` → `80/5/[]`
- [x] End-to-end regression on folder tree: `ctx query "Why do I avoid squats?"` still resolves squat + knee-pain unchanged
- [x] `test_llm_synthesiser.py` widen-on-gap test still passes (verified via full suite)
- [x] New engine progression test: fake synthesiser returning `missing=[...]` triggers `stats.widens_level_1 == 1`, `stats.widens_level_2 == 1`, `response.gap_flag == True`
- [x] Downgrade test: `downgrade_threshold=2` + 2 consecutive same-signature failures → `stats.strategy_downgrades == 1` and strategy node's `metadata.downgrade_count == 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)