### PR TITLE
Interactive REPL with trace mode (closes #8)

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -174,6 +174,30 @@ Phased, each phase produces a runnable system that passes its own tests.
   caps) + 3 new engine tests (three-tier progression, no-widen success,
   downgrade-fires-after-threshold); full suite 78 passed + 3 skipped
 
+## Phase 14 — graph editor REPL ✅
+
+- `TraceEvent` dataclass added to `traversal.py`; `Traverser.__init__` gains an
+  optional `observer: Callable[[TraceEvent], None]` parameter
+- Events emitted inside `_bfs_from`: `seed`, `pop`, `collect`, `expand`, `done`
+  (budget exhaustion); and `rule_chain` inside `_close_rule_chains`
+- Observer call is a single `if` check — zero overhead when not set; no
+  `TraceEvent` objects constructed unless observer is present
+- New `src/context_engine/repl.py`: `Repl` class with `run()` loop and
+  `execute(line) -> bool` seam; commands: `help`, `show`, `neighbors`, `query`,
+  `set-weight`, `trace`, `stats`, `quit`/`exit`/`q`
+- `query` command accepts `"<text>" [seed1 seed2 ...]` and diffs the new slice
+  against the previous one using green `+`, red `-`, and dim unchanged lines
+- `trace` command runs a fresh `Traverser` with an event collector and prints
+  all events as a rich Table; output is deterministic for a fixed graph/seeds
+- Pretty output via `rich.console.Console`, `rich.table.Table`,
+  `rich.panel.Panel` — only these three rich primitives used
+- `ctx repl` subcommand wired into `cli.py`; `Repl` import is lazy so other
+  subcommands pay no startup cost
+- `rich>=13.0` added to `[project].dependencies` in `pyproject.toml`
+- Tests: 8 new tests in `tests/test_repl.py` (help, show, neighbors,
+  set-weight, query, trace determinism, quit, unknown command);
+  full suite 86 passed + 3 skipped
+
 ## Next (beyond v0.1)
 
 1. **LLM classifier** — drop-in replacement for `KeywordClassifier`, uses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "numpy>=1.26",
     "pyyaml>=6.0",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -48,6 +48,8 @@ def main(argv: list[str] | None = None) -> int:
     p_query.add_argument("--seed", action="append", default=[], help="explicit seed node id")
     p_query.add_argument("--filter", help="metadata filter as JSON")
 
+    sub.add_parser("repl", help="interactive graph editor")
+
     sub.add_parser("dump")
 
     p_import = sub.add_parser("import", help="build the graph from a folder tree")
@@ -99,6 +101,13 @@ def main(argv: list[str] | None = None) -> int:
         query = Query(text=args.text, explicit_refs=args.seed)
         resp = engine.answer(query, metadata_filter=metadata_filter)
         print(resp.text)
+        return 0
+
+    if args.cmd == "repl":
+        from context_engine.repl import Repl  # noqa: PLC0415
+
+        engine = ContextEngine(store)
+        Repl(store=store, engine=engine).run()
         return 0
 
     if args.cmd == "dump":

--- a/src/context_engine/repl.py
+++ b/src/context_engine/repl.py
@@ -1,0 +1,242 @@
+"""Interactive REPL for inspecting and editing the context graph.
+
+Provides live inspection of nodes and edges, weight mutation, query replay,
+and step-by-step traversal tracing — all against a live ``GraphStore``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from context_engine.store import GraphStore
+from context_engine.traversal import TraceEvent, Traverser
+from context_engine.types import Query
+
+if TYPE_CHECKING:
+    from context_engine.engine import ContextEngine
+
+
+_COMMANDS = ("help", "show", "neighbors", "query", "set-weight", "trace", "stats", "quit")
+
+
+class Repl:
+    """Interactive graph editor and query replayer.
+
+    Parameters
+    ----------
+    store:
+        The graph store to inspect and mutate.
+    engine:
+        Optional ``ContextEngine`` for ``query`` and ``trace`` commands.
+        Without it those two commands print a warning and no-op.
+    """
+
+    def __init__(self, store: GraphStore, engine: ContextEngine | None = None) -> None:
+        self.store = store
+        self.engine = engine
+        self.console = Console()
+        self._last_slice_ids: set[str] = set()
+
+    # ── public interface ────────────────────────────────────────────────────
+
+    def run(self) -> None:
+        """Start the REPL loop. Blocks until the user quits."""
+        self.console.print(Panel("context-engine repl — type 'help' for commands"))
+        while True:
+            try:
+                line = input("ctx> ")
+            except (EOFError, KeyboardInterrupt):
+                self.console.print()
+                return
+            if not line.strip():
+                continue
+            if self.execute(line):
+                return
+
+    def execute(self, line: str) -> bool:
+        """Execute one REPL command.
+
+        Returns ``True`` when the loop should exit, ``False`` otherwise.
+        """
+        try:
+            parts = shlex.split(line)
+        except ValueError as exc:
+            self.console.print(f"[red]parse error: {exc}[/red]")
+            return False
+
+        if not parts:
+            return False
+
+        cmd, *args = parts
+
+        if cmd in ("quit", "exit", "q"):
+            return True
+        if cmd == "help":
+            self._cmd_help()
+        elif cmd == "show":
+            self._cmd_show(args)
+        elif cmd == "neighbors":
+            self._cmd_neighbors(args)
+        elif cmd == "query":
+            self._cmd_query(args)
+        elif cmd == "set-weight":
+            self._cmd_set_weight(args)
+        elif cmd == "trace":
+            self._cmd_trace(args)
+        elif cmd == "stats":
+            self._cmd_stats()
+        else:
+            self.console.print(f"unknown command: {cmd}; type help for list")
+
+        return False
+
+    # ── command implementations ─────────────────────────────────────────────
+
+    def _cmd_help(self) -> None:
+        t = Table(show_header=True, header_style="bold")
+        t.add_column("command")
+        t.add_column("args")
+        t.add_column("description")
+        t.add_row("show", "<id>", "print node content and metadata")
+        t.add_row("neighbors", "<id>", "print outgoing edges")
+        t.add_row("query", '"<text>" [seed1 seed2 ...]', "run query, show diff against last slice")
+        t.add_row("set-weight", "<edge_id> <value>", "update an edge weight")
+        t.add_row("trace", '"<text>" [seed1 seed2 ...]', "show priority-queue expansion steps")
+        t.add_row("stats", "", "print engine stats")
+        t.add_row("quit", "", "exit the REPL (also: exit, q)")
+        self.console.print(t)
+
+    def _cmd_show(self, args: list[str]) -> None:
+        if not args:
+            self.console.print("[yellow]usage: show <node_id>[/yellow]")
+            return
+        node = self.store.get_node(args[0])
+        if node is None:
+            self.console.print(f"[red]node not found: {args[0]}[/red]")
+            return
+        t = Table(show_header=False)
+        t.add_column("key")
+        t.add_column("value")
+        t.add_row("id", node.id)
+        t.add_row("content", node.content)
+        t.add_row("type", node.type or "")
+        t.add_row("status", node.status or "")
+        t.add_row("created_at", str(node.created_at))
+        for k, v in node.metadata.items():
+            if k not in ("type", "status"):
+                t.add_row(k, str(v))
+        self.console.print(t)
+
+    def _cmd_neighbors(self, args: list[str]) -> None:
+        if not args:
+            self.console.print("[yellow]usage: neighbors <node_id>[/yellow]")
+            return
+        edges = self.store.out_edges(args[0])
+        if not edges:
+            self.console.print(f"no outgoing edges from {args[0]!r}")
+            return
+        t = Table(show_header=True, header_style="bold")
+        t.add_column("edge_id")
+        t.add_column("type")
+        t.add_column("target")
+        t.add_column("weight")
+        t.add_column("content")
+        for e in edges:
+            t.add_row(e.id, e.type, e.target, f"{e.weight:.3f}", e.content or "")
+        self.console.print(t)
+
+    def _cmd_query(self, args: list[str]) -> None:
+        if self.engine is None:
+            self.console.print("[yellow]no engine configured[/yellow]")
+            return
+        if not args:
+            self.console.print('[yellow]usage: query "<text>" [seed1 seed2 ...][/yellow]')
+            return
+        text = args[0]
+        explicit_refs = args[1:]
+        query = Query(text=text, explicit_refs=explicit_refs)
+        resp = self.engine.answer(query)
+        new_ids = {n.id for n in resp.slice_.nodes}
+
+        # Diff against previous slice
+        added = new_ids - self._last_slice_ids
+        removed = self._last_slice_ids - new_ids
+        kept = new_ids & self._last_slice_ids
+
+        for nid in sorted(kept):
+            self.console.print(f"  {nid}", style="dim")
+        for nid in sorted(added):
+            self.console.print(f"+ {nid}", style="green")
+        for nid in sorted(removed):
+            self.console.print(f"- {nid}", style="red")
+
+        self._last_slice_ids = new_ids
+
+    def _cmd_set_weight(self, args: list[str]) -> None:
+        if len(args) < 2:
+            self.console.print("[yellow]usage: set-weight <edge_id> <value>[/yellow]")
+            return
+        edge_id = args[0]
+        try:
+            value = float(args[1])
+        except ValueError:
+            self.console.print(f"[red]invalid weight: {args[1]}[/red]")
+            return
+        self.store.update_edge_weight(edge_id, value)
+        self.console.print(f"updated edge {edge_id!r} weight → {value:.4f}")
+
+    def _cmd_trace(self, args: list[str]) -> None:
+        if self.engine is None:
+            self.console.print("[yellow]no engine configured[/yellow]")
+            return
+        if not args:
+            self.console.print('[yellow]usage: trace "<text>" [seed1 seed2 ...][/yellow]')
+            return
+        text = args[0]
+        explicit_refs = args[1:]
+        query = Query(text=text, explicit_refs=explicit_refs)
+
+        # Reproduce engine.answer() setup, but with an observer-equipped traverser.
+        tuple_ = self.engine.classifier.classify(query)
+        seeds = self.engine.seeds.select(query)
+        strategy = self.engine.strategies.resolve(tuple_, seeds=seeds)
+
+        events: list[TraceEvent] = []
+        tracer = Traverser(self.store, strategies=self.engine.strategies, observer=events.append)
+        tracer.traverse(strategy, tuple_)
+
+        t = Table(show_header=True, header_style="bold")
+        t.add_column("#", justify="right")
+        t.add_column("kind")
+        t.add_column("depth", justify="right")
+        t.add_column("node")
+        t.add_column("edge")
+        t.add_column("priority")
+        t.add_column("reason")
+        for i, ev in enumerate(events):
+            t.add_row(
+                str(i),
+                ev.kind,
+                str(ev.depth),
+                ev.node_id or "",
+                ev.edge_id or "",
+                f"{ev.priority:.4f}" if ev.priority is not None else "",
+                ev.reason or "",
+            )
+        self.console.print(t)
+
+    def _cmd_stats(self) -> None:
+        if self.engine is None:
+            self.console.print("[yellow]no engine configured[/yellow]")
+            return
+        t = Table(show_header=False)
+        t.add_column("stat")
+        t.add_column("value", justify="right")
+        for k, v in self.engine.stats.items():
+            t.add_row(k, str(v))
+        self.console.print(t)

--- a/src/context_engine/traversal.py
+++ b/src/context_engine/traversal.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import heapq
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from context_engine.store import GraphStore
@@ -37,6 +38,18 @@ from context_engine.types import (
 )
 
 
+@dataclass
+class TraceEvent:
+    """A single step emitted by the traverser when an observer is installed."""
+
+    kind: str  # "seed", "pop", "collect", "expand", "skip", "rule_chain", "done"
+    depth: int
+    node_id: str | None = None
+    edge_id: str | None = None
+    priority: float | None = None
+    reason: str | None = None
+
+
 @dataclass(order=True)
 class _PQItem:
     priority: float
@@ -46,9 +59,15 @@ class _PQItem:
 
 
 class Traverser:
-    def __init__(self, store: GraphStore, strategies: StrategyResolver | None = None) -> None:
+    def __init__(
+        self,
+        store: GraphStore,
+        strategies: StrategyResolver | None = None,
+        observer: Callable[[TraceEvent], None] | None = None,
+    ) -> None:
         self.store = store
         self.strategies = strategies
+        self.observer = observer
 
     # ── public entry ────────────────────────────────────────────────────────
 
@@ -153,6 +172,9 @@ class Traverser:
             return
         seed_type = seed_node.type
 
+        if self.observer is not None:
+            self.observer(TraceEvent(kind="seed", depth=0, node_id=seed))
+
         pq: list[_PQItem] = []
         heapq.heappush(pq, _PQItem(priority=0.0, depth=0, node_id=seed))
         visited: set[str] = set()
@@ -164,12 +186,31 @@ class Traverser:
                 continue
             visited.add(item.node_id)
 
+            if self.observer is not None:
+                self.observer(
+                    TraceEvent(
+                        kind="pop",
+                        depth=item.depth,
+                        node_id=item.node_id,
+                        priority=item.priority,
+                    )
+                )
+
             # Add node to the slice
             if item.node_id not in collected_node_ids:
                 collected_node_ids.add(item.node_id)
                 collected_this_run += 1
                 if item.via_edge is not None:
                     collected_edges[item.via_edge.id] = item.via_edge
+                if self.observer is not None:
+                    self.observer(
+                        TraceEvent(
+                            kind="collect",
+                            depth=item.depth,
+                            node_id=item.node_id,
+                            edge_id=item.via_edge.id if item.via_edge is not None else None,
+                        )
+                    )
 
             if item.depth >= strategy.depth:
                 continue
@@ -180,6 +221,7 @@ class Traverser:
                 edge_types=strategy.edge_types or None,
                 weight_floor=strategy.weight_floor,
             )
+            depth = item.depth + 1
             for edge in edges:
                 if edge.target in visited:
                     continue
@@ -191,7 +233,7 @@ class Traverser:
                 prio = self._priority(
                     edge=edge,
                     target=target,
-                    depth=item.depth + 1,
+                    depth=depth,
                     seed_type=seed_type,
                     strategy=strategy,
                     tuple_=tuple_,
@@ -201,11 +243,24 @@ class Traverser:
                     pq,
                     _PQItem(
                         priority=prio,
-                        depth=item.depth + 1,
+                        depth=depth,
                         node_id=edge.target,
                         via_edge=edge,
                     ),
                 )
+                if self.observer is not None:
+                    self.observer(
+                        TraceEvent(
+                            kind="expand",
+                            depth=depth,
+                            node_id=edge.target,
+                            edge_id=edge.id,
+                            priority=prio,
+                        )
+                    )
+
+        if self.observer is not None and collected_this_run >= budget:
+            self.observer(TraceEvent(kind="done", depth=0, reason=f"budget {budget} reached"))
 
     # ── priority function ──────────────────────────────────────────────────
 
@@ -282,6 +337,16 @@ class Traverser:
                     continue
                 collected_node_ids.add(edge.target)
                 added += 1
+                if self.observer is not None:
+                    self.observer(
+                        TraceEvent(
+                            kind="rule_chain",
+                            depth=0,
+                            node_id=edge.target,
+                            edge_id=edge.id,
+                            reason="rule chain closure",
+                        )
+                    )
                 if target.type == "rule" and edge.target not in seen:
                     frontier.append(edge.target)
                     seen.add(edge.target)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,103 @@
+"""Tests for the interactive REPL (context_engine.repl).
+
+Each test calls ``Repl.execute()`` directly — no stdin simulation needed.
+Output is captured by swapping ``repl.console`` for a recording Console.
+"""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+from context_engine.engine import ContextEngine
+from context_engine.repl import Repl
+from context_engine.store import GraphStore
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_repl(store: GraphStore) -> tuple[Repl, Console]:
+    """Return a Repl wired to a recording console."""
+    engine = ContextEngine(store)
+    repl = Repl(store=store, engine=engine)
+    rec = Console(record=True, width=120)
+    repl.console = rec
+    return repl, rec
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+
+def test_help_lists_all_commands(store: GraphStore) -> None:
+    repl, rec = _make_repl(store)
+    repl.execute("help")
+    out = rec.export_text()
+    for cmd in ("show", "neighbors", "query", "set-weight", "trace", "quit", "stats"):
+        assert cmd in out, f"help output missing command: {cmd!r}"
+
+
+def test_show_prints_node_content(store: GraphStore) -> None:
+    repl, rec = _make_repl(store)
+    repl.execute("show squat")
+    out = rec.export_text()
+    assert "squat" in out
+    assert "avoided" in out
+
+
+def test_neighbors_prints_outgoing_edges(store: GraphStore) -> None:
+    repl, rec = _make_repl(store)
+    repl.execute("neighbors squat")
+    out = rec.export_text()
+    assert "because_of" in out
+    assert "knee" in out
+
+
+def test_set_weight_persists(store: GraphStore) -> None:
+    # squat → knee edge
+    edges = store.out_edges("squat")
+    assert edges, "fixture must have edges from squat"
+    edge = edges[0]
+    repl, _ = _make_repl(store)
+    result = repl.execute(f"set-weight {edge.id} 0.25")
+    assert result is False
+    updated = store.get_edge(edge.id)
+    assert updated is not None
+    assert abs(updated.weight - 0.25) < 1e-6
+
+
+def test_query_runs_and_stores_last_slice(store: GraphStore) -> None:
+    repl, rec = _make_repl(store)
+    # Pass squat as an explicit seed so the query finds something.
+    result = repl.execute('query "why avoid squats" squat')
+    assert result is False
+    # After a successful query the slice must be non-empty.
+    assert len(repl._last_slice_ids) > 0  # noqa: SLF001
+
+
+def test_trace_is_deterministic(store: GraphStore) -> None:
+    engine = ContextEngine(store)
+
+    rec1 = Console(record=True, width=120)
+    repl1 = Repl(store=store, engine=engine)
+    repl1.console = rec1
+    repl1.execute('trace "why avoid squats" squat')
+    out1 = rec1.export_text()
+
+    rec2 = Console(record=True, width=120)
+    repl2 = Repl(store=store, engine=engine)
+    repl2.console = rec2
+    repl2.execute('trace "why avoid squats" squat')
+    out2 = rec2.export_text()
+
+    assert out1 == out2
+
+
+def test_quit_returns_true(store: GraphStore) -> None:
+    repl, _ = _make_repl(store)
+    assert repl.execute("quit") is True
+
+
+def test_unknown_command_does_not_raise(store: GraphStore) -> None:
+    repl, rec = _make_repl(store)
+    result = repl.execute("nonsense")
+    assert result is False
+    assert "unknown command" in rec.export_text()


### PR DESCRIPTION
## Summary

- New `ctx repl` subcommand launches an interactive graph editor
- `Repl.execute(line)` is the testable seam — handles one command, returns `True` to quit. Tests never touch `input()`.
- Commands: `help`, `show <id>`, `neighbors <id>`, `query "<text>" [seeds...]`, `set-weight <edge_id> <value>`, `trace "<text>" [seeds...]`, `stats`, `quit`/`exit`/`q`
- New `TraceEvent` dataclass + optional `observer: Callable[[TraceEvent], None]` on `Traverser.__init__`. Observer fires for seed, pop, collect, expand, rule_chain, and done events. Zero overhead when no observer is attached.
- `query` command remembers the last slice and diffs the next one against it — green `+` for added nodes, red `−` for removed, dim for unchanged
- `trace` command runs the full classify → seed → strategy → traverse pipeline with an observer, then renders the event stream as a `rich.Table`
- New dependency: `rich>=13.0` (the only new dep — matches issue acceptance criteria)

## Scoping

Single subagent, one worktree, 6 files touched:

| File | Change |
|---|---|
| `src/context_engine/repl.py` | NEW — 242 LOC |
| `src/context_engine/traversal.py` | +68 LOC — `TraceEvent` + observer hook |
| `src/context_engine/cli.py` | +9 LOC — `repl` subcommand |
| `pyproject.toml` | +1 line — `rich>=13.0` |
| `tests/test_repl.py` | NEW — 103 LOC, 8 tests |
| `docs/implementation-plan.md` | Phase 14 entry |

No other files touched. The traversal observer is strictly additive — zero changes to which nodes end up in the slice.

## Test plan

- [x] **86 passed + 3 skipped** (up from 78+3, +8 new REPL tests)
- [x] `ruff check` clean
- [x] `tests/test_traversal.py` — all 4 existing tests still green (critical regression target)
- [x] `tests/test_repl.py::test_trace_is_deterministic` — two identical trace runs produce byte-for-byte equal output
- [x] Smoke test: `help`, `show n1`, `quit` all execute without raising on an in-memory store
- [x] End-to-end trace on folder-tree fixture: `trace "why do I avoid squats" exercises/squat` renders 6 events showing `squat → knee-pain` via `because_of` edge with priority 1.1
- [x] No heavy dependencies — only `rich>=13.0` added as specified in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)