### PR TITLE
Fix JSON encoder crash on date/datetime metadata values

### DIFF
--- a/src/context_engine/store.py
+++ b/src/context_engine/store.py
@@ -13,7 +13,7 @@ import struct
 import uuid
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +24,23 @@ EMBED_DIM = 384  # default; override via GraphStore(embed_dim=...)
 
 def _now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _json_default(value: Any) -> Any:
+    """Coerce metadata values that are not natively JSON-serialisable.
+
+    YAML frontmatter parses ``2026-02-14`` as :class:`datetime.date` and
+    ``2026-02-14T10:00:00`` as :class:`datetime.datetime`; both land here.
+    Any other non-scalar value is stringified as a last resort so a single
+    bad key cannot break an entire import.
+    """
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    return str(value)
+
+
+def _dumps(value: Any) -> str:
+    return json.dumps(value, default=_json_default)
 
 
 def _pack_embedding(vec: list[float]) -> bytes:
@@ -133,7 +150,7 @@ class GraphStore:
                 metadata=excluded.metadata,
                 updated_at=excluded.updated_at
             """,
-            (node_id, content, json.dumps(meta), now, now),
+            (node_id, content, _dumps(meta), now, now),
         )
         if embedding is not None:
             self._set_embedding(node_id, embedding)
@@ -200,7 +217,7 @@ class GraphStore:
                 metadata=excluded.metadata,
                 updated_at=excluded.updated_at
             """,
-            (edge_id, source, target, content, json.dumps(meta), now, now),
+            (edge_id, source, target, content, _dumps(meta), now, now),
         )
         return self.get_edge(edge_id)  # type: ignore[return-value]
 
@@ -240,7 +257,7 @@ class GraphStore:
         meta["weight"] = max(0.0, min(1.0, new_weight))
         self._conn.execute(
             "UPDATE edges SET metadata=?, updated_at=? WHERE id=?",
-            (json.dumps(meta), _now(), edge_id),
+            (_dumps(meta), _now(), edge_id),
         )
 
     # ── embeddings / seed search ────────────────────────────────────────────

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date, datetime
+
 from context_engine.store import GraphStore
 
 
@@ -32,3 +34,21 @@ def test_out_edges_filter(store: GraphStore) -> None:
     edges = store.out_edges("ohp", edge_types=["has_observation"])
     assert len(edges) == 5
     assert all(e.type == "has_observation" for e in edges)
+
+
+def test_upsert_node_coerces_date_metadata() -> None:
+    """YAML frontmatter parses dates as datetime.date; they must round-trip
+    as ISO strings rather than explode the JSON encoder."""
+    s = GraphStore(":memory:")
+    n = s.upsert_node(
+        "hello",
+        metadata={
+            "type": "decision",
+            "decided_on": date(2026, 2, 14),
+            "noticed_at": datetime(2026, 2, 14, 10, 30),
+        },
+    )
+    fetched = s.get_node(n.id)
+    assert fetched is not None
+    assert fetched.metadata["decided_on"] == "2026-02-14"
+    assert fetched.metadata["noticed_at"].startswith("2026-02-14T10:30")


### PR DESCRIPTION
## Summary

Caught during first real dogfooding on a non-fixture knowledge tree. A `readme.md` with YAML frontmatter containing `decided_on: 2026-02-14` crashed `ctx import` because PyYAML parses bare dates as `datetime.date`, which `json.dumps` rejects.

## Fix

Single `_dumps()` helper in `store.py` routes every metadata serialisation through `json.dumps(value, default=_json_default)` where `_json_default` coerces `date` / `datetime` to ISO strings and falls back to `str()` for anything else. One bad key can no longer kill an entire import.

All three `json.dumps` sites (`upsert_node`, `upsert_edge`, `update_edge_weight`) now go through the helper.

## Test plan

- [x] New regression test `test_upsert_node_coerces_date_metadata` verifies both `date` and `datetime` round-trip as ISO strings
- [x] 87 passed + 3 skipped (+1 new test)
- [x] `ruff check` clean
- [x] End-to-end retry with the original failing fixture: `ctx import` → `ctx index` → `ctx query "why did we pick postgres over sqlite?"` returns a 511-char slice containing both the decision and its upstream constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)