### PR TITLE
Global graph with project-level composition (closes #23)

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -334,6 +334,45 @@ Phased, each phase produces a runnable system that passes its own tests.
 - Tests: 11 new tests in `tests/test_garden.py`, 1 new test in `tests/test_cli.py`
 - Full suite: 125 passed + 4 skipped
 
+## Phase 20 — global graph with project-level composition ✅
+
+Closes issue #23. Completes the pro v1 roadmap.
+
+### Goals
+
+Enable cross-project knowledge by adding a global graph at `~/.ctx/global.db`
+(override via `CTX_GLOBAL_DB`). Project queries automatically compose with the
+global graph; local nodes always win on id collision.
+
+### Implementation
+
+- New `src/context_engine/composed_store.py`: `ComposedStore` — duck-typed
+  read-only wrapper over two `GraphStore` instances. Implements `get_node`,
+  `get_nodes`, `out_edges`, `in_edges`, `get_edge`, `knn`, `all_node_ids`.
+  Project store takes priority; edge results are unioned.
+- `src/context_engine/seeds.py`: `SeedSelector` gains optional `global_store`
+  parameter. Seed selection draws from both stores via a `ComposedStore`.
+- `src/context_engine/engine.py`: `ContextEngine` gains optional `global_store`
+  parameter. When present, wraps both stores in a `ComposedStore` for
+  traversal. Writes (feedback, strategy mutations) always target the project
+  store only.
+- `src/context_engine/cli.py`:
+  - `--global` top-level flag routes operations to the global db.
+  - `global-init` subcommand creates `~/.ctx/global.db`, `~/.ctx/knowledge/`,
+    and a `~/.ctx/README.md`.
+  - `query` command uses `_build_engine_with_global_fallback` to automatically
+    compose with the global graph when `~/.ctx/global.db` exists.
+- Tests: 4 new tests in `tests/test_composed_store.py`, 1 in `tests/test_engine.py`,
+  1 in `tests/test_cli.py`.
+- Full suite: 131 passed + 4 skipped
+
+## End of pro v1 roadmap
+
+All 20 phases complete. The engine now supports:
+semantic search, graph traversal, progressive widening, strategy learning,
+feedback loops, incremental import, LLM-assisted edges, graph health
+diagnostics, and global cross-project knowledge composition.
+
 ## Next (beyond v0.1)
 
 1. **LLM classifier** — drop-in replacement for `KeywordClassifier`, uses

--- a/src/context_engine/cli.py
+++ b/src/context_engine/cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -226,9 +227,57 @@ def _cmd_suggest_edges(args: argparse.Namespace, store: GraphStore) -> int:
     return 0
 
 
+def _global_db_path() -> Path:
+    return Path(os.environ.get("CTX_GLOBAL_DB", Path.home() / ".ctx" / "global.db"))
+
+
+def _build_engine_with_global_fallback(
+    store: GraphStore, embedder: HashEmbedder | None = None
+) -> ContextEngine:
+    global_path = _global_db_path()
+    global_store = GraphStore(global_path) if global_path.exists() else None
+    if embedder is None:
+        embedder = HashEmbedder(dim=store.embed_dim)
+    return ContextEngine(store, embedder=embedder, global_store=global_store)
+
+
+def _cmd_global_init() -> int:
+    global_path = _global_db_path()
+    global_root = global_path.parent
+    global_root.mkdir(parents=True, exist_ok=True)
+    knowledge_dir = global_root / "knowledge"
+    knowledge_dir.mkdir(exist_ok=True)
+    # Create (or touch) the database by opening a GraphStore.
+    GraphStore(global_path).close()
+    readme_path = global_root / "README.md"
+    if not readme_path.exists():
+        readme_path.write_text(
+            "# Global context-engine graph\n\n"
+            "This directory holds knowledge that applies across all projects.\n\n"
+            "## Layout\n\n"
+            "- `global.db` — the SQLite graph database\n"
+            "- `knowledge/` — source nodes as markdown files (one per folder)\n\n"
+            "## Usage\n\n"
+            "Add nodes with:\n\n"
+            "    ctx --global add-node \"your convention\""
+            " --id conventions/my-rule --type convention\n\n"
+            "Import from a folder tree:\n\n"
+            "    ctx --global import knowledge/\n",
+            encoding="utf-8",
+        )
+    print(f"initialised global graph at {global_path}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="ctx")
     parser.add_argument("--db", default="graph.db", help="sqlite path")
+    parser.add_argument(
+        "--global",
+        dest="use_global",
+        action="store_true",
+        help="target the global db (~/.ctx/global.db) instead of the project db",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("init", help="create empty db")
@@ -302,8 +351,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_suggest.add_argument("--max-candidates", type=int, default=50)
 
+    sub.add_parser("global-init", help="create the global graph at ~/.ctx/global.db")
+
     args = parser.parse_args(argv)
-    store = GraphStore(Path(args.db))
+
+    # Resolve effective db path: --global overrides --db.
+    db_path = _global_db_path() if args.use_global else Path(args.db)
+    store = GraphStore(db_path)
 
     if args.cmd == "init":
         print(f"initialised {args.db}")
@@ -333,10 +387,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "query":
         embedder = HashEmbedder(dim=store.embed_dim)
         # Derive tree_root from the db path: look for a knowledge/ sibling directory.
-        db_path = Path(args.db).resolve()
-        candidate = db_path.parent / "knowledge"
+        resolved_db = db_path.resolve()
+        candidate = resolved_db.parent / "knowledge"
         tree_root = candidate if candidate.is_dir() else None
-        engine = ContextEngine(store, embedder=embedder, tree_root=tree_root)
+        engine = _build_engine_with_global_fallback(store, embedder=embedder)
+        # Wire tree_root into the feedback applier after construction.
+        if tree_root is not None:
+            from context_engine.feedback import FeedbackApplier  # noqa: PLC0415
+
+            engine.feedback = FeedbackApplier(
+                store, strategies=engine.strategies, tree_root=tree_root
+            )
         metadata_filter = json.loads(args.filter) if args.filter else None
         query = Query(text=args.text, explicit_refs=args.seed)
         resp = engine.answer(query, metadata_filter=metadata_filter)
@@ -420,6 +481,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.cmd == "suggest-edges":
         return _cmd_suggest_edges(args, store)
+
+    if args.cmd == "global-init":
+        return _cmd_global_init()
 
     parser.print_help()
     return 1

--- a/src/context_engine/composed_store.py
+++ b/src/context_engine/composed_store.py
@@ -1,0 +1,111 @@
+"""Read-only composite over two GraphStore instances.
+
+Provides the subset of GraphStore methods used by Traverser and SeedSelector.
+The project store takes priority: on node id collisions the project version wins.
+Edge results are unioned across both stores.
+"""
+
+from __future__ import annotations
+
+from context_engine.store import GraphStore
+from context_engine.types import Edge, Node
+
+
+class ComposedStore:
+    """Duck-typed read-only view over a project store plus a global fallback store.
+
+    Only implements the methods actually called by Traverser and SeedSelector:
+    get_node, get_nodes, out_edges, in_edges, get_edge, knn, all_node_ids.
+    """
+
+    def __init__(self, project: GraphStore, global_: GraphStore) -> None:
+        self._project = project
+        self._global = global_
+
+    # ── node access ────────────────────────────────────────────────────────
+
+    def get_node(self, node_id: str) -> Node | None:
+        node = self._project.get_node(node_id)
+        if node is not None:
+            return node
+        return self._global.get_node(node_id)
+
+    def get_nodes(self, node_ids: list[str]) -> list[Node]:
+        # Project wins on id collision; fill missing from global.
+        project_map = {n.id: n for n in self._project.get_nodes(node_ids)}
+        missing = [nid for nid in node_ids if nid not in project_map]
+        global_nodes = self._global.get_nodes(missing) if missing else []
+        global_map = {n.id: n for n in global_nodes}
+        # Preserve order.
+        result: list[Node] = []
+        for nid in node_ids:
+            if nid in project_map:
+                result.append(project_map[nid])
+            elif nid in global_map:
+                result.append(global_map[nid])
+        return result
+
+    def all_node_ids(self) -> list[str]:
+        project_ids = set(self._project.all_node_ids())
+        global_ids = set(self._global.all_node_ids())
+        return list(project_ids | global_ids)
+
+    # ── edge access ────────────────────────────────────────────────────────
+
+    def out_edges(
+        self,
+        node_id: str,
+        edge_types: list[str] | None = None,
+        weight_floor: float = 0.0,
+    ) -> list[Edge]:
+        project_edges = self._project.out_edges(
+            node_id, edge_types=edge_types, weight_floor=weight_floor
+        )
+        global_edges = self._global.out_edges(
+            node_id, edge_types=edge_types, weight_floor=weight_floor
+        )
+        # Union: project edge ids take priority.
+        seen_ids = {e.id for e in project_edges}
+        deduped_global = [e for e in global_edges if e.id not in seen_ids]
+        return project_edges + deduped_global
+
+    def in_edges(
+        self,
+        node_id: str,
+        edge_types: list[str] | None = None,
+        weight_floor: float = 0.0,
+    ) -> list[Edge]:
+        project_edges = self._project.in_edges(
+            node_id, edge_types=edge_types, weight_floor=weight_floor
+        )
+        global_edges = self._global.in_edges(
+            node_id, edge_types=edge_types, weight_floor=weight_floor
+        )
+        seen_ids = {e.id for e in project_edges}
+        deduped_global = [e for e in global_edges if e.id not in seen_ids]
+        return project_edges + deduped_global
+
+    def get_edge(self, edge_id: str) -> Edge | None:
+        edge = self._project.get_edge(edge_id)
+        if edge is not None:
+            return edge
+        return self._global.get_edge(edge_id)
+
+    # ── vector similarity ──────────────────────────────────────────────────
+
+    def knn(self, vec: list[float], k: int = 5) -> list[tuple[str, float]]:
+        """Merge knn results from both stores, project wins on id collision."""
+        project_results = self._project.knn(vec, k=k)
+        global_results = self._global.knn(vec, k=k)
+
+        # Merge and deduplicate; project ids win on collision.
+        seen_ids = {nid for nid, _ in project_results}
+        merged = list(project_results)
+        for nid, dist in global_results:
+            if nid not in seen_ids:
+                merged.append((nid, dist))
+                seen_ids.add(nid)
+
+        # Re-sort by distance, return top-k.
+        merged.sort(key=lambda t: t[1])
+        return merged[:k]

--- a/src/context_engine/engine.py
+++ b/src/context_engine/engine.py
@@ -107,8 +107,10 @@ class ContextEngine:
         auto_feedback: bool = False,
         downgrade_threshold: int = 3,
         tree_root: Path | None = None,
+        global_store: GraphStore | None = None,
     ) -> None:
         self.store = store
+        self.global_store = global_store
         self.classifier = classifier or KeywordClassifier()
         self.synthesiser = synthesiser or OfflineSynthesiser()
         self._embedder = embedder
@@ -119,10 +121,19 @@ class ContextEngine:
             self._embedder = embedder
         # embedder.embed takes precedence over the raw embed_fn callable.
         resolved_embed_fn = embedder.embed if embedder is not None else embed_fn
-        self.seeds = SeedSelector(store, embed_fn=resolved_embed_fn)
+        self.seeds = SeedSelector(store, embed_fn=resolved_embed_fn, global_store=global_store)
         self.strategies = StrategyResolver(store)
-        self.traverser = Traverser(store, strategies=self.strategies)
+
+        # Compose traversal store: project + global fallback, or just project.
+        if global_store is not None:
+            from context_engine.composed_store import ComposedStore  # noqa: PLC0415
+
+            traversal_store: GraphStore = ComposedStore(store, global_store)  # type: ignore[assignment]
+        else:
+            traversal_store = store
+        self.traverser = Traverser(traversal_store, strategies=self.strategies)
         self.logic = LogicEngine()
+        # Writes always go to the project store only.
         self.feedback = FeedbackApplier(store, strategies=self.strategies, tree_root=tree_root)
         self.auto_feedback = auto_feedback
         self.downgrade_threshold = downgrade_threshold

--- a/src/context_engine/seeds.py
+++ b/src/context_engine/seeds.py
@@ -13,9 +13,13 @@ Returning zero seeds is valid: scan intents run without seeds.
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from context_engine.store import GraphStore
 from context_engine.types import Query
+
+if TYPE_CHECKING:
+    from context_engine.composed_store import ComposedStore
 
 
 class SeedSelector:
@@ -23,9 +27,19 @@ class SeedSelector:
         self,
         store: GraphStore,
         embed_fn: Callable[[str], list[float]] | None = None,
+        global_store: GraphStore | None = None,
     ) -> None:
         self.store = store
         self.embed_fn = embed_fn
+        self.global_store = global_store
+
+    def _composed(self) -> GraphStore | ComposedStore:
+        """Return a ComposedStore when a global store is present, else the project store."""
+        if self.global_store is not None:
+            from context_engine.composed_store import ComposedStore  # noqa: PLC0415
+
+            return ComposedStore(self.store, self.global_store)
+        return self.store
 
     def select(
         self,
@@ -33,29 +47,34 @@ class SeedSelector:
         metadata_filter: dict[str, object] | None = None,
         k: int = 5,
     ) -> list[str]:
+        composed = self._composed()
         seeds: list[str] = []
 
         # 1. explicit references (ids the caller provided)
         for ref in query.explicit_refs:
-            if self.store.get_node(ref) is not None:
+            if composed.get_node(ref) is not None:
                 seeds.append(ref)
 
-        # 2. metadata filter
+        # 2. metadata filter — only project store supports filter_nodes
         if metadata_filter:
             for node in self.store.filter_nodes(metadata_filter):
                 if node.id not in seeds:
                     seeds.append(node.id)
+            if self.global_store is not None:
+                for node in self.global_store.filter_nodes(metadata_filter):
+                    if node.id not in seeds:
+                        seeds.append(node.id)
 
         # 3. vector similarity
         if not seeds and self.embed_fn is not None:
             vec = self.embed_fn(query.text)
-            for node_id, _dist in self.store.knn(vec, k=k):
+            for node_id, _dist in composed.knn(vec, k=k):
                 if node_id not in seeds:
                     seeds.append(node_id)
 
         # 4. conversation context (append, not replace)
         for cid in query.conversation_node_ids:
-            if cid not in seeds and self.store.get_node(cid) is not None:
+            if cid not in seeds and composed.get_node(cid) is not None:
                 seeds.append(cid)
 
         return seeds[:k] if seeds else seeds

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,3 +111,16 @@ def test_suggest_edges_non_interactive_mocked(tmp_path: Path, capsys) -> None:
     captured = capsys.readouterr()
     assert "b" in captured.out
     assert "supports" in captured.out
+
+
+def test_global_init_creates_structure(tmp_path: Path, monkeypatch) -> None:
+    """global-init creates global.db and a knowledge/ directory."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    rc = main(["global-init"])
+    assert rc == 0
+
+    global_db = tmp_path / ".ctx" / "global.db"
+    knowledge_dir = tmp_path / ".ctx" / "knowledge"
+    assert global_db.exists(), f"expected global.db at {global_db}"
+    assert knowledge_dir.is_dir(), f"expected knowledge/ dir at {knowledge_dir}"

--- a/tests/test_composed_store.py
+++ b/tests/test_composed_store.py
@@ -1,0 +1,66 @@
+"""Tests for ComposedStore."""
+
+from __future__ import annotations
+
+from context_engine.composed_store import ComposedStore
+from context_engine.store import GraphStore
+
+
+def _make_store() -> GraphStore:
+    return GraphStore(":memory:")
+
+
+def test_project_node_wins_on_id_collision() -> None:
+    project = _make_store()
+    global_ = _make_store()
+    project.upsert_node("project version", node_id="x")
+    global_.upsert_node("global version", node_id="x")
+
+    composed = ComposedStore(project, global_)
+    node = composed.get_node("x")
+    assert node is not None
+    assert node.content == "project version"
+
+
+def test_global_node_visible_when_absent_from_project() -> None:
+    project = _make_store()
+    global_ = _make_store()
+    global_.upsert_node("global only", node_id="y")
+
+    composed = ComposedStore(project, global_)
+    node = composed.get_node("y")
+    assert node is not None
+    assert node.content == "global only"
+
+
+def test_out_edges_union() -> None:
+    project = _make_store()
+    global_ = _make_store()
+
+    project.upsert_node("a", node_id="a")
+    project.upsert_node("b", node_id="b")
+    project.upsert_edge("a", "b", edge_type="type1")
+
+    global_.upsert_node("a", node_id="a")
+    global_.upsert_node("c", node_id="c")
+    global_.upsert_edge("a", "c", edge_type="type2")
+
+    composed = ComposedStore(project, global_)
+    edges = composed.out_edges("a")
+    targets = {e.target for e in edges}
+    assert "b" in targets
+    assert "c" in targets
+
+
+def test_all_node_ids_merged() -> None:
+    project = _make_store()
+    global_ = _make_store()
+
+    project.upsert_node("a", node_id="a")
+    project.upsert_node("b", node_id="b")
+    global_.upsert_node("b", node_id="b")
+    global_.upsert_node("c", node_id="c")
+
+    composed = ComposedStore(project, global_)
+    ids = set(composed.all_node_ids())
+    assert ids == {"a", "b", "c"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -146,3 +146,25 @@ def test_engine_uses_default_embedder_when_none_passed() -> None:
     engine = ContextEngine(store)
     assert engine._embedder is not None
     assert isinstance(engine._embedder, (SentenceTransformerEmbedder, HashEmbedder))
+
+
+def test_engine_composes_global_graph_for_seeds() -> None:
+    """Global-store nodes are visible in query results when the project store has none."""
+    from context_engine.embedding import HashEmbedder
+
+    project = GraphStore(":memory:")
+    global_ = GraphStore(":memory:")
+
+    embedder = HashEmbedder(dim=project.embed_dim)
+
+    # Global store has a node about pathlib; project store is empty.
+    global_.upsert_node("normalize paths with pathlib", node_id="conventions/pathlib")
+    global_._set_embedding("conventions/pathlib", embedder.embed("normalize paths with pathlib"))
+
+    engine = ContextEngine(project, embedder=embedder, global_store=global_)
+    resp = engine.answer(Query(text="how to normalize paths"))
+
+    node_ids = {n.id for n in resp.slice_.nodes}
+    assert "conventions/pathlib" in node_ids, (
+        f"expected global node 'conventions/pathlib' in slice, got {node_ids}"
+    )


### PR DESCRIPTION
## Summary

- New `ComposedStore` (`src/context_engine/composed_store.py`) — read-only duck-typed wrapper that overlays a project store on top of a global store. Project wins on id collision; edges are unioned.
- `SeedSelector` and `ContextEngine` gain an optional `global_store` parameter. When present, seeds are drawn from both stores and traversal runs against a composed view.
- Writes (feedback, strategy mutations, learned edges) stay on the project store only. The global store is effectively read-only from the engine's perspective.
- New `ctx global-init` subcommand creates `~/.ctx/global.db` and `~/.ctx/knowledge/`
- New top-level `--global` flag targets the global db for `ctx` subcommands that take `--db`
- `ctx query` automatically composes with `~/.ctx/global.db` (or `CTX_GLOBAL_DB` if set) when that file exists, so project queries transparently fall back to global knowledge.

## Pro v1 complete

**6 of 6 pro-v1 issues landed.** This closes the roadmap from v0.1 (completeness) to daily-usable quality:

1. ✓ #18 Real semantic embeddings (sentence-transformers)
2. ✓ #19 Incremental import with content-hash caching
3. ✓ #20 Unified frontmatter edges + weights sidecar
4. ✓ #21 LLM-assisted edge suggestion with interactive accept flow
5. ✓ #22 cx garden diagnostic
6. ✓ #23 Global graph + composition (this PR)

## Test plan

- [x] **131 passed + 4 skipped** (up from 125+4, +6 new tests: 4 composed store + 1 engine + 1 cli)
- [x] `ruff check` clean
- [x] ComposedStore tests: project wins on collision, global visible when absent from project, out_edges union, all_node_ids merged
- [x] Engine test: semantic query against a project with no matching content finds a global node via composition
- [x] CLI test: `global-init` creates the expected structure under a tmp home
- [x] End-to-end smoke: added a node to `$CTX_GLOBAL_DB`, bootstrapped a fresh empty project, ran `ctx query "what about normalizing paths"` from the project — the global `conventions/pathlib` node was surfaced via composition. Exact scenario from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)